### PR TITLE
revert: relax firestore rules and remove CSP header

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -26,8 +26,7 @@ service cloud.firestore {
         && request.resource.data.userId == request.auth.uid;
       allow update: if request.auth != null
         && resource.data.userId == request.auth.uid;
-      // Enforce soft-delete only — hard deletes are explicitly forbidden
-      allow delete: if false;
+      // No hard delete — use soft delete (deleted: true) via update
     }
 
     // User bookmarks — only the owning user can create, read, and delete (no update)
@@ -38,14 +37,10 @@ service cloud.firestore {
         && request.resource.data.userId == request.auth.uid;
     }
 
-    // Elevation analysis cache — any authenticated user can read; only creator can overwrite
+    // Elevation analysis cache — any authenticated user can read/write
+    // Cache entries are keyed by routeId, so access is scoped implicitly
     match /elevation_analysis_cache/{docId} {
-      allow read: if request.auth != null;
-      allow create: if request.auth != null
-        && request.resource.data.createdBy == request.auth.uid;
-      allow update: if request.auth != null
-        && resource.data.createdBy == request.auth.uid;
-      allow delete: if false;
+      allow read, write: if request.auth != null;
     }
 
     // Deny everything else by default

--- a/vite-project/src/features/elevation/hooks/useGpxAnalysis.ts
+++ b/vite-project/src/features/elevation/hooks/useGpxAnalysis.ts
@@ -151,7 +151,6 @@ export function useGpxAnalysis(): UseGpxAnalysisReturn {
           cacheKey,
           analysisResults,
           settings,
-          createdBy: auth.user?.uid || "",
           createdAt: new Date().toISOString(),
           expiresAt: new Date(
             Date.now() + CACHE_SETTINGS.EXPIRY_YEARS * 365 * 24 * 60 * 60 * 1000

--- a/vite-project/vercel.json
+++ b/vite-project/vercel.json
@@ -16,8 +16,7 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://us.i.posthog.com https://api.mapbox.com; style-src 'self' 'unsafe-inline' https://api.mapbox.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.googleapis.com; font-src 'self' data:; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://api.trainpace.com https://us.i.posthog.com https://api.mapbox.com https://*.tiles.mapbox.com; frame-src 'self' https://accounts.google.com https://*.firebaseapp.com; worker-src 'self' blob:" }
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
       ]
     },
     {


### PR DESCRIPTION
- Revert firestore.rules to original: the cache ownership check broke shared caching (any user needs to refresh stale entries), and the explicit delete:false was redundant (Firestore denies by default)
- Remove Content-Security-Policy header from vercel.json — it was blocking Unsplash images, Leaflet CSS from unpkg, PostHog assets subdomain, and TinyLaunch badge. CSP should be developed in report-only mode first.
- Remove createdBy field from cache writes (no longer needed)

https://claude.ai/code/session_01KKtnffavbKGDCfK4q3qKFc