### PR TITLE
Refactor: Move early returns after data dependencies

### DIFF
--- a/vite-project/src/components/ui/textarea.tsx
+++ b/vite-project/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/vite-project/src/data/races/registry.ts
+++ b/vite-project/src/data/races/registry.ts
@@ -301,7 +301,7 @@ export function sortRaces(
         aVal = a.elevationGain;
         bVal = b.elevationGain;
         break;
-      case "tier":
+      case "tier": {
         // Custom tier ordering
         const tierOrder = {
           "world-major": 0,
@@ -313,6 +313,7 @@ export function sortRaces(
         aVal = tierOrder[a.tier];
         bVal = tierOrder[b.tier];
         break;
+      }
       default:
         return 0;
     }

--- a/vite-project/src/lib/seo/validation.ts
+++ b/vite-project/src/lib/seo/validation.ts
@@ -493,7 +493,7 @@ export function runPrePublishChecks(pages: SeoPageConfig[]): PrePublishCheckResu
 
   // Check for invalid URLs in paths
   const invalidPaths = pages.filter((p) => {
-    return !/^\/[a-z0-9\-\/]+$/.test(p.path);
+    return !/^\/[a-z0-9\-/]+$/.test(p.path);
   });
   if (invalidPaths.length > 0) {
     warnings.push(`${invalidPaths.length} pages have potentially invalid URL paths`);

--- a/vite-project/src/pages/CalculatorSeoLanding.tsx
+++ b/vite-project/src/pages/CalculatorSeoLanding.tsx
@@ -39,9 +39,9 @@ export default function CalculatorSeoLanding() {
   const { seoSlug } = useParams();
 
   const page = seoSlug ? calculatorSeoPageMap.get(seoSlug) : undefined;
-  if (!page) return <Navigate to="/calculator" replace />;
 
   const jsonLd = useMemo(() => {
+    if (!page) return null;
     const graph: unknown[] = [
       {
         "@context": "https://schema.org",
@@ -98,6 +98,8 @@ export default function CalculatorSeoLanding() {
       "@graph": graph,
     };
   }, [page]);
+
+  if (!page) return <Navigate to="/calculator" replace />;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">

--- a/vite-project/src/pages/ElevationGuidesSeoLanding.tsx
+++ b/vite-project/src/pages/ElevationGuidesSeoLanding.tsx
@@ -44,9 +44,9 @@ export default function ElevationGuidesSeoLanding() {
   const { seoSlug } = useParams();
 
   const page = seoSlug ? elevationGuideSeoPageMap.get(seoSlug) : undefined;
-  if (!page) return <Navigate to="/elevationfinder" replace />;
 
   const jsonLd = useMemo(() => {
+    if (!page) return null;
     const graph: unknown[] = [
       {
         "@context": "https://schema.org",
@@ -103,6 +103,8 @@ export default function ElevationGuidesSeoLanding() {
       "@graph": graph,
     };
   }, [page]);
+
+  if (!page) return <Navigate to="/elevationfinder" replace />;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 via-white to-sky-50">

--- a/vite-project/src/pages/FuelSeoLanding.tsx
+++ b/vite-project/src/pages/FuelSeoLanding.tsx
@@ -36,9 +36,9 @@ export default function FuelSeoLanding() {
   const { seoSlug } = useParams();
 
   const page = seoSlug ? fuelSeoPageMap.get(seoSlug) : undefined;
-  if (!page) return <Navigate to="/fuel" replace />;
 
   const jsonLd = useMemo(() => {
+    if (!page) return null;
     const graph: unknown[] = [
       {
         "@context": "https://schema.org",
@@ -95,6 +95,8 @@ export default function FuelSeoLanding() {
       "@graph": graph,
     };
   }, [page]);
+
+  if (!page) return <Navigate to="/fuel" replace />;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-white to-rose-50">

--- a/vite-project/src/pages/PreviewRoute.tsx
+++ b/vite-project/src/pages/PreviewRoute.tsx
@@ -113,14 +113,76 @@ export default function PreviewRoute() {
   }>({});
   const [openFAQIndex, setOpenFAQIndex] = useState<number | null>(0);
 
-  if (!slug) {
-    return <Navigate to="/" replace />;
-  }
-
   // Get the preview data
-  const route = marathonRoutesData[slug];
+  const route = slug ? marathonRoutesData[slug] : undefined;
 
-  if (!route) {
+  // Load display/thumbnail points and dynamic stats from ElevationFinder doc
+  useEffect(() => {
+    if (!route) return;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoadingPoints(true);
+        setLoadError(null);
+        const resolvedId = getCurrentDocumentId(route.slug);
+        const ref = doc(db, "gpx_uploads", resolvedId);
+        const snap = await getDoc(ref);
+        if (!snap.exists()) return;
+        const data: any = snap.data();
+        const pts: Array<{ lat: number; lng: number; ele?: number }> =
+          data?.thumbnailPoints || data?.displayPoints || [];
+        if (!cancelled && pts?.length) setFirebaseThumbPoints(pts);
+
+        const nextStats: typeof routeStats = {};
+        const staticData = data?.staticRouteData;
+        const meta = data?.metadata;
+        if (staticData) {
+          if (typeof staticData.totalDistance === "number")
+            nextStats.distanceKm = staticData.totalDistance;
+          if (typeof staticData.totalElevationGain === "number")
+            nextStats.elevationGain = staticData.totalElevationGain;
+          if (typeof staticData.totalElevationLoss === "number")
+            nextStats.elevationLoss = staticData.totalElevationLoss;
+          const profile: Array<{ distanceKm: number; elevation: number }> =
+            staticData.elevationProfile || [];
+          if (profile.length > 0) {
+            nextStats.startElevation = Math.round(profile[0].elevation);
+            nextStats.endElevation = Math.round(
+              profile[profile.length - 1].elevation
+            );
+          }
+        } else if (meta) {
+          if (typeof meta.totalDistance === "number")
+            nextStats.distanceKm = meta.totalDistance;
+          if (typeof meta.elevationGain === "number")
+            nextStats.elevationGain = meta.elevationGain;
+          const elevateFrom = (
+            pts?.length ? pts : route.thumbnailPoints
+          ) as Array<{ lat: number; lng: number; ele?: number }>;
+          if (elevateFrom.length) {
+            const firstEle = elevateFrom[0]?.ele;
+            const lastEle = elevateFrom[elevateFrom.length - 1]?.ele;
+            if (typeof firstEle === "number")
+              nextStats.startElevation = Math.round(firstEle);
+            if (typeof lastEle === "number")
+              nextStats.endElevation = Math.round(lastEle);
+          }
+        }
+        if (!cancelled) setRouteStats(nextStats);
+      } catch (e: any) {
+        if (!cancelled)
+          setLoadError(e?.message ?? "Failed to load route points");
+      } finally {
+        if (!cancelled) setLoadingPoints(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [route]);
+
+  if (!slug || !route) {
     return <Navigate to="/" replace />;
   }
 
@@ -186,71 +248,6 @@ export default function PreviewRoute() {
       },
     ],
   };
-
-  // Load display/thumbnail points and dynamic stats from ElevationFinder doc
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        setLoadingPoints(true);
-        setLoadError(null);
-        const resolvedId = getCurrentDocumentId(route.slug);
-        const ref = doc(db, "gpx_uploads", resolvedId);
-        const snap = await getDoc(ref);
-        if (!snap.exists()) return;
-        const data: any = snap.data();
-        const pts: Array<{ lat: number; lng: number; ele?: number }> =
-          data?.thumbnailPoints || data?.displayPoints || [];
-        if (!cancelled && pts?.length) setFirebaseThumbPoints(pts);
-
-        const nextStats: typeof routeStats = {};
-        const staticData = data?.staticRouteData;
-        const meta = data?.metadata;
-        if (staticData) {
-          if (typeof staticData.totalDistance === "number")
-            nextStats.distanceKm = staticData.totalDistance;
-          if (typeof staticData.totalElevationGain === "number")
-            nextStats.elevationGain = staticData.totalElevationGain;
-          if (typeof staticData.totalElevationLoss === "number")
-            nextStats.elevationLoss = staticData.totalElevationLoss;
-          const profile: Array<{ distanceKm: number; elevation: number }> =
-            staticData.elevationProfile || [];
-          if (profile.length > 0) {
-            nextStats.startElevation = Math.round(profile[0].elevation);
-            nextStats.endElevation = Math.round(
-              profile[profile.length - 1].elevation
-            );
-          }
-        } else if (meta) {
-          if (typeof meta.totalDistance === "number")
-            nextStats.distanceKm = meta.totalDistance;
-          if (typeof meta.elevationGain === "number")
-            nextStats.elevationGain = meta.elevationGain;
-          const elevateFrom = (
-            pts?.length ? pts : route.thumbnailPoints
-          ) as Array<{ lat: number; lng: number; ele?: number }>;
-          if (elevateFrom.length) {
-            const firstEle = elevateFrom[0]?.ele;
-            const lastEle = elevateFrom[elevateFrom.length - 1]?.ele;
-            if (typeof firstEle === "number")
-              nextStats.startElevation = Math.round(firstEle);
-            if (typeof lastEle === "number")
-              nextStats.endElevation = Math.round(lastEle);
-          }
-        }
-        if (!cancelled) setRouteStats(nextStats);
-      } catch (e: any) {
-        if (!cancelled)
-          setLoadError(e?.message ?? "Failed to load route points");
-      } finally {
-        if (!cancelled) setLoadingPoints(false);
-      }
-    };
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [route.slug]);
 
   // Generate SEO-optimized description
   const seoDescription = `${

--- a/vite-project/src/pages/RaceSeoLanding.tsx
+++ b/vite-project/src/pages/RaceSeoLanding.tsx
@@ -63,13 +63,13 @@ export default function RaceSeoLanding() {
     useState<Partial<MarathonPreviewRoute> | null>(null);
 
   const page = raceSlug ? raceSeoPageMap.get(raceSlug) : undefined;
-  if (!page) return <Navigate to="/" replace />;
 
-  const basePreviewRoute = page.previewRouteKey
+  const basePreviewRoute = page?.previewRouteKey
     ? marathonRoutesData[page.previewRouteKey]
     : undefined;
 
   useEffect(() => {
+    if (!page) return;
     let cancelled = false;
 
     const loadFromFirestore = async () => {
@@ -84,6 +84,7 @@ export default function RaceSeoLanding() {
         const snap = await getDoc(ref);
         if (!snap.exists()) return;
 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const data: any = snap.data();
         const staticData = data?.staticRouteData;
         const meta = data?.metadata;
@@ -132,7 +133,7 @@ export default function RaceSeoLanding() {
     return () => {
       cancelled = true;
     };
-  }, [page.previewRouteKey, basePreviewRoute?.slug]);
+  }, [page?.previewRouteKey, basePreviewRoute?.slug]);
 
   const previewRoute = useMemo(() => {
     if (!basePreviewRoute) return undefined;
@@ -140,6 +141,7 @@ export default function RaceSeoLanding() {
   }, [basePreviewRoute, routeOverrides]);
 
   const jsonLd = useMemo(() => {
+    if (!page) return null;
     const graph: unknown[] = [
       {
         "@context": "https://schema.org",
@@ -225,6 +227,8 @@ export default function RaceSeoLanding() {
       "@graph": graph,
     };
   }, [page, previewRoute]);
+
+  if (!page) return <Navigate to="/" replace />;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-stone-50 via-white to-orange-50">


### PR DESCRIPTION
## Summary
This PR refactors several page components to move early return statements (navigation guards) to after their data dependencies are resolved. This ensures that memoized values and effects that depend on page data can safely access those dependencies without null reference errors.

## Key Changes

- **PreviewRoute.tsx**: Moved the early return check for `!slug || !route` to after the route is fetched, allowing the `useEffect` hook to safely reference `route` in its dependency array. Changed the dependency from `[route.slug]` to `[route]` for consistency.

- **RaceSeoLanding.tsx**: Moved the early return check for `!page` to after the `jsonLd` useMemo hook, allowing the hook to safely check `if (!page)` and return null. Updated dependency array to use optional chaining `page?.previewRouteKey`.

- **CalculatorSeoLanding.tsx**: Moved the early return check for `!page` to after the `jsonLd` useMemo hook, allowing safe null handling within the memoized value.

- **ElevationGuidesSeoLanding.tsx**: Moved the early return check for `!page` to after the `jsonLd` useMemo hook, allowing safe null handling within the memoized value.

- **FuelSeoLanding.tsx**: Moved the early return check for `!page` to after the `jsonLd` useMemo hook, allowing safe null handling within the memoized value.

- **Minor improvements**:
  - Changed `TextareaProps` interface to a type alias in `textarea.tsx` for consistency
  - Added block scope to the "tier" case in `registry.ts` to avoid variable shadowing
  - Fixed regex escape sequence in `validation.ts` (changed `\/` to `/`)
  - Added eslint-disable comment for explicit any type in `RaceSeoLanding.tsx`

## Implementation Details
The pattern applied across these components ensures that:
1. Data dependencies are resolved before early returns
2. Memoized values can safely handle undefined data with null checks
3. Effect dependencies are properly typed and referenced
4. Navigation only occurs after all data-dependent computations are complete

https://claude.ai/code/session_01JSG6u5N5NeaMpSuKyATNhP