### PR TITLE
feat(calculator): Runna/Strava-style UX with suggested times, VDOT badge, and time slider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,15 @@ Wrap the page component with `<AuthGuard>` in `src/App.tsx`.
 - `usePacePlanPersistence.ts` — localStorage + Firestore persistence
 - Types: `PaceInputs`, `PaceResults`, `DistanceUnit` (`'km' | 'miles'`), `PaceUnit`
 
+**UX features added April 2026 (Runna/Strava-style redesign):**
+- `SUGGESTED_TIMES` — contextual goal-time chips per preset distance (e.g. "Sub 3h", "3:30", "4:00" for Marathon). Tapping a chip fills HH:MM:SS and **auto-calculates** without a button press.
+- `SLIDER_RANGES` — per-distance min/max/step config; a fine-tune slider appears once a preset distance is selected and a valid time exists. Dragging rewrites the HH:MM:SS fields live.
+- **Live VDOT badge** — `⚡ VDOT 45.2 · Intermediate` updates in real time using `calculateVdot` imported from `@/features/vdot-calculator/vdot-math`.
+- **Auto-advance focus** HH → MM → SS after 2 digits typed.
+- `onPresetClick` now takes `(distance: number, presetName: string)` — the preset name drives which suggested times and slider range are shown.
+
+**Saving is unchanged** — `handleSave` → `SavePlanDialog` → `saveToDashboard` → Firestore path is identical. Guest-redirect flow via sessionStorage also unchanged.
+
 ### VDOT Calculator (`src/features/vdot-calculator/`)
 Jack Daniels VDOT scoring tool. Refactored March 2026 from 998-line monolith into 12 focused components with dashboard layout.
 

--- a/vite-project/src/features/pace-calculator/components/PaceCalculatorV2.tsx
+++ b/vite-project/src/features/pace-calculator/components/PaceCalculatorV2.tsx
@@ -72,15 +72,22 @@ export function PaceCalculatorV2({
 
   // Live VDOT – updates as user types
   const liveVdot = useMemo(() => {
+    if (errors.time) return null;
+
     const dist = parseFloat(inputs.distance);
     if (!dist || dist <= 0) return null;
+
+    const minutes = parseInt(inputs.minutes || "0", 10);
+    const seconds = parseInt(inputs.seconds || "0", 10);
+    if (minutes >= 60 || seconds >= 60) return null;
+
     const totalSecs = timeToSeconds(inputs.hours, inputs.minutes, inputs.seconds);
     if (totalSecs <= 0) return null;
     const distMeters = inputs.units === "km" ? dist * 1000 : dist * 1609.34;
     const vdot = calculateVdot(distMeters, totalSecs);
     if (!isFinite(vdot) || vdot < 10 || vdot > 100) return null;
     return Math.round(vdot * 10) / 10;
-  }, [inputs.distance, inputs.units, inputs.hours, inputs.minutes, inputs.seconds]);
+  }, [inputs.distance, inputs.units, inputs.hours, inputs.minutes, inputs.seconds, errors.time]);
 
   // Auto-calculate when a suggested-time chip is tapped
   useEffect(() => {
@@ -123,6 +130,10 @@ export function PaceCalculatorV2({
       const numValue = value.replace(/\D/g, "");
       setInputs((prev) => ({ ...prev, [name]: numValue.slice(0, 2) }));
       return;
+    }
+
+    if (name === "distance") {
+      setSelectedPresetName(null);
     }
 
     setInputs((prev) => ({ ...prev, [name]: value }));

--- a/vite-project/src/features/pace-calculator/components/PaceCalculatorV2.tsx
+++ b/vite-project/src/features/pace-calculator/components/PaceCalculatorV2.tsx
@@ -3,17 +3,19 @@
  * Modern UI similar to fuel planner
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Helmet } from "react-helmet-async";
 import { Card, CardContent } from "@/components/ui/card";
 import { Info, ChevronDown, ChevronUp } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { usePendingPacePlan } from "@/hooks/usePendingPacePlan";
 import ReactGA from "react-ga4";
+import { calculateVdot } from "@/features/vdot-calculator/vdot-math";
 
 import type { PaceInputs, PaceResults, FormErrors, PaceUnit } from "../types";
 import { usePaceCalculation } from "../hooks/usePaceCalculation";
 import { usePacePlanPersistence } from "../hooks/usePacePlanPersistence";
+import { timeToSeconds } from "../utils";
 import { RaceDetailsForm } from "./RaceDetailsForm";
 import { PaceResultsDisplay } from "./PaceResultsDisplay";
 import { SavePlanDialog } from "./SavePlanDialog";
@@ -50,6 +52,12 @@ export function PaceCalculatorV2({
   const [errors, setErrors] = useState<FormErrors>({});
   const [isCalculating, setIsCalculating] = useState(false);
 
+  // Track which preset button was last clicked so we can show contextual chips
+  const [selectedPresetName, setSelectedPresetName] = useState<string | null>(null);
+
+  // When true the next valid calculation result is auto-committed (e.g. chip click)
+  const [autoCalc, setAutoCalc] = useState(false);
+
   // UI state
   const [showInfo, setShowInfo] = useState(false);
   const [showPhilosophy, setShowPhilosophy] = useState(false);
@@ -62,7 +70,37 @@ export function PaceCalculatorV2({
   const { isSaving, isSaved, saveToDashboard, resetSaveState } =
     usePacePlanPersistence();
 
-  // Auto-update results when pace type changes
+  // Live VDOT – updates as user types
+  const liveVdot = useMemo(() => {
+    const dist = parseFloat(inputs.distance);
+    if (!dist || dist <= 0) return null;
+    const totalSecs = timeToSeconds(inputs.hours, inputs.minutes, inputs.seconds);
+    if (totalSecs <= 0) return null;
+    const distMeters = inputs.units === "km" ? dist * 1000 : dist * 1609.34;
+    const vdot = calculateVdot(distMeters, totalSecs);
+    if (!isFinite(vdot) || vdot < 10 || vdot > 100) return null;
+    return Math.round(vdot * 10) / 10;
+  }, [inputs.distance, inputs.units, inputs.hours, inputs.minutes, inputs.seconds]);
+
+  // Auto-calculate when a suggested-time chip is tapped
+  useEffect(() => {
+    if (autoCalc && calculation.isValid && calculation.result) {
+      setResults(calculation.result);
+      setAutoCalc(false);
+      toast({
+        title: "Calculation Complete! ✨",
+        description: "Your training paces have been calculated.",
+        duration: 3000,
+      });
+      ReactGA.event({
+        category: "Pace Calculator",
+        action: "Calculated Paces",
+        label: `${inputs.distance}${inputs.units} (suggested time)`,
+      });
+    }
+  }, [autoCalc, calculation.isValid, calculation.result, inputs.distance, inputs.units]);
+
+  // Auto-update results when pace type changes (user is already on results screen)
   useEffect(() => {
     if (results && calculation.isValid && calculation.result) {
       setResults(calculation.result);
@@ -76,47 +114,59 @@ export function PaceCalculatorV2({
     label: "User opened the Pace Calculator",
   });
 
-  // Handlers
-  const handleInputChange = (e: {
-    target: { name: string; value: string };
-  }) => {
+  // ── Handlers ────────────────────────────────────────────────────────────────
+
+  const handleInputChange = (e: { target: { name: string; value: string } }) => {
     const { name, value } = e.target;
 
-    // Time input validation
     if (["hours", "minutes", "seconds"].includes(name)) {
       const numValue = value.replace(/\D/g, "");
-      setInputs((prev) => ({
-        ...prev,
-        [name]: numValue.slice(0, 2),
-      }));
+      setInputs((prev) => ({ ...prev, [name]: numValue.slice(0, 2) }));
       return;
     }
 
-    setInputs((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
+    setInputs((prev) => ({ ...prev, [name]: value }));
 
-    // Clear errors for this field
     if (errors[name as keyof FormErrors]) {
-      setErrors((prev) => ({
-        ...prev,
-        [name]: undefined,
-      }));
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
     }
   };
 
-  const handlePreset = (distance: number) => {
+  /** Called by distance preset buttons – now also tracks the preset name */
+  const handlePreset = (distance: number, presetName: string) => {
+    setInputs((prev) => ({ ...prev, distance: distance.toString() }));
+    setSelectedPresetName(presetName);
+    setErrors({});
+  };
+
+  /** Tapping a suggested-time chip fills HH/MM/SS and auto-calculates */
+  const handleSuggestedTimeClick = (h: string, m: string, s: string) => {
     setInputs((prev) => ({
       ...prev,
-      distance: distance.toString(),
+      hours:   h === "0" ? "" : h,
+      minutes: m,
+      seconds: s,
     }));
     setErrors({});
+    setAutoCalc(true);
+  };
+
+  /** Slider drag – decompose total seconds into HH/MM/SS fields */
+  const handleSliderChange = (totalSeconds: number) => {
+    const h = Math.floor(totalSeconds / 3600);
+    const m = Math.floor((totalSeconds % 3600) / 60);
+    const s = totalSeconds % 60;
+    setInputs((prev) => ({
+      ...prev,
+      hours:   h > 0 ? h.toString() : "",
+      minutes: m.toString(),
+      seconds: s.toString(),
+    }));
   };
 
   const handleCalculate = () => {
     if (!calculation.isValid) {
-      setErrors(calculation.errors);
+      setErrors(calculation.errors as FormErrors);
       toast({
         title: "Validation Error",
         description: "Please check the form for errors.",
@@ -159,12 +209,7 @@ export function PaceCalculatorV2({
   };
 
   const handlePaceTypeChange = (newPaceType: PaceUnit) => {
-    // Update the input state
-    setInputs((prev) => ({
-      ...prev,
-      paceType: newPaceType,
-    }));
-
+    setInputs((prev) => ({ ...prev, paceType: newPaceType }));
     ReactGA.event({
       category: "Pace Calculator",
       action: "Changed Pace Type",
@@ -180,19 +225,13 @@ export function PaceCalculatorV2({
 
     Object.entries(results).forEach(([key, value]) => {
       const displayName = key === "xlong" ? "Long Run" : key;
-      text += `${
-        displayName.charAt(0).toUpperCase() + displayName.slice(1)
-      }: ${value}\n`;
+      text += `${displayName.charAt(0).toUpperCase() + displayName.slice(1)}: ${value}\n`;
     });
 
     try {
       await navigator.clipboard.writeText(text);
       toast({ title: "Copied to clipboard! 📋" });
-
-      ReactGA.event({
-        category: "Pace Calculator",
-        action: "Copied Plan",
-      });
+      ReactGA.event({ category: "Pace Calculator", action: "Copied Plan" });
     } catch {
       toast({ title: "Failed to copy", variant: "destructive" });
     }
@@ -206,9 +245,7 @@ export function PaceCalculatorV2({
 
     Object.entries(results).forEach(([key, value]) => {
       const displayName = key === "xlong" ? "Long Run" : key;
-      text += `${
-        displayName.charAt(0).toUpperCase() + displayName.slice(1)
-      }: ${value}\n`;
+      text += `${displayName.charAt(0).toUpperCase() + displayName.slice(1)}: ${value}\n`;
     });
 
     const blob = new Blob([text], { type: "text/plain" });
@@ -220,11 +257,7 @@ export function PaceCalculatorV2({
     URL.revokeObjectURL(url);
 
     toast({ title: "Download started! 💾" });
-
-    ReactGA.event({
-      category: "Pace Calculator",
-      action: "Downloaded Plan",
-    });
+    ReactGA.event({ category: "Pace Calculator", action: "Downloaded Plan" });
   };
 
   const handleSave = async () => {
@@ -238,25 +271,19 @@ export function PaceCalculatorV2({
     raceDate?: string
   ) => {
     if (!results) return;
-
-    await saveToDashboard({
-      inputs,
-      results,
-      planName,
-      notes,
-      raceDate,
-    });
-
+    await saveToDashboard({ inputs, results, planName, notes, raceDate });
     setShowSaveDialog(false);
   };
 
   const getRaceTime = () => {
     const parts = [];
-    if (inputs.hours) parts.push(`${inputs.hours}h`);
+    if (inputs.hours)   parts.push(`${inputs.hours}h`);
     if (inputs.minutes) parts.push(`${inputs.minutes}m`);
     if (inputs.seconds) parts.push(`${inputs.seconds}s`);
     return parts.join(" ");
   };
+
+  // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
     <>
@@ -276,10 +303,7 @@ export function PaceCalculatorV2({
               description:
                 "Use your recent race time to calculate personalized training paces for Easy, Tempo, Threshold, and Interval runs using VDOT methodology.",
               totalTime: "PT1M",
-              tool: {
-                "@type": "HowToTool",
-                name: "TrainPace Calculator",
-              },
+              tool: { "@type": "HowToTool", name: "TrainPace Calculator" },
               step: [
                 {
                   "@type": "HowToStep",
@@ -315,9 +339,7 @@ export function PaceCalculatorV2({
         <div className="max-w-7xl mx-auto">
           {/* Header */}
           <div className="flex items-center justify-between mb-8">
-            <h1 className="text-4xl font-bold text-gray-900">
-              ⏱️ Pace Calculator
-            </h1>
+            <h1 className="text-4xl font-bold text-gray-900">⏱️ Pace Calculator</h1>
             <button
               onClick={() => setShowInfo(!showInfo)}
               className="p-3 rounded-full bg-white shadow-md hover:shadow-lg transition-all"
@@ -347,7 +369,6 @@ export function PaceCalculatorV2({
 
           {/* Main Content */}
           <div className="max-w-4xl mx-auto space-y-8">
-            {/* Race Details OR Results */}
             {!results ? (
               <RaceDetailsForm
                 inputs={inputs}
@@ -356,6 +377,10 @@ export function PaceCalculatorV2({
                 onPresetClick={handlePreset}
                 onCalculate={handleCalculate}
                 isCalculating={isCalculating}
+                selectedPresetName={selectedPresetName}
+                liveVdot={liveVdot}
+                onSuggestedTimeClick={handleSuggestedTimeClick}
+                onSliderChange={handleSliderChange}
               />
             ) : (
               <PaceResultsDisplay
@@ -380,9 +405,7 @@ export function PaceCalculatorV2({
               onClick={() => setShowPhilosophy(!showPhilosophy)}
               className="w-full flex items-center justify-between p-4 bg-white rounded-xl shadow-md hover:shadow-lg transition-all"
             >
-              <span className="text-lg font-semibold text-gray-900">
-                Training Philosophy
-              </span>
+              <span className="text-lg font-semibold text-gray-900">Training Philosophy</span>
               {showPhilosophy ? (
                 <ChevronUp className="h-5 w-5 text-gray-600" />
               ) : (

--- a/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
+++ b/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
@@ -98,7 +98,9 @@ export function RaceDetailsForm({
 
   // Derived totals
   const currentTimeSeconds = timeToSeconds(inputs.hours, inputs.minutes, inputs.seconds);
-  const hasValidTime = currentTimeSeconds > 0;
+  const minutes = parseInt(inputs.minutes || "0", 10);
+  const seconds = parseInt(inputs.seconds || "0", 10);
+  const hasValidTime = currentTimeSeconds > 0 && minutes < 60 && seconds < 60;
 
   // Which suggested chip (if any) matches current time
   const activeChipLabel = hasValidTime
@@ -179,7 +181,8 @@ export function RaceDetailsForm({
                 errors.distance ? "border-red-500" : "border-gray-300"
               }`}
             />
-            <div
+            <button
+              type="button"
               className="relative w-32 h-10 bg-blue-100 rounded-full cursor-pointer overflow-hidden flex-shrink-0"
               onClick={handleUnitToggle}
             >
@@ -192,7 +195,7 @@ export function RaceDetailsForm({
                 <div className={`w-1/2 text-center text-sm font-medium transition-colors ${isKm ? "text-white" : "text-blue-700"}`}>KM</div>
                 <div className={`w-1/2 text-center text-sm font-medium transition-colors ${!isKm ? "text-white" : "text-blue-700"}`}>MI</div>
               </div>
-            </div>
+            </button>
           </div>
           {errors.distance && <p className="text-red-500 text-sm">{errors.distance}</p>}
         </div>
@@ -284,7 +287,7 @@ export function RaceDetailsForm({
         </div>
 
         {/* ── 4. Fine-tune slider (preset distances only, after time is entered) ── */}
-        {sliderRange && hasValidTime && (
+        {sliderRange && hasValidTime && !errors.time && (
           <div className="bg-gray-50 rounded-2xl p-4 space-y-3 border border-gray-100">
             <div className="flex items-center justify-between text-xs text-gray-500">
               <span>Faster</span>

--- a/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
+++ b/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
@@ -1,8 +1,17 @@
 /**
- * Race Details Form Component - Updated Modern UI
- * Clean, spacious form for race inputs similar to fuel planner
+ * Race Details Form – Runna/Strava-inspired redesign
+ *
+ * New UX:
+ *  1. Distance preset pills (existing)
+ *  2. Suggested finishing-time chips – contextual to selected distance
+ *  3. HH : MM : SS time inputs with auto-advance focus
+ *  4. Fine-tune slider (appears for preset distances)
+ *  5. Live VDOT badge
+ *  6. Optional age / temperature adjustments
  */
 
+import { useRef } from "react";
+import { Zap } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Tooltip,
@@ -10,18 +19,59 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { PRESET_DISTANCES } from "../types";
-import { convertDistance } from "../utils";
+import { PRESET_DISTANCES, SUGGESTED_TIMES, SLIDER_RANGES } from "../types";
+import { convertDistance, timeToSeconds } from "../utils";
 import type { PaceInputs, FormErrors } from "../types";
+
+// ─── VDOT level helper (local to avoid tight cross-feature coupling) ─────────
+
+interface VdotLevel {
+  label: string;
+  color: string;
+  bg: string;
+}
+
+function getVdotLevelLocal(vdot: number): VdotLevel {
+  if (vdot >= 70) return { label: "Elite",         color: "text-red-600",     bg: "bg-red-50 border-red-200"     };
+  if (vdot >= 60) return { label: "Advanced",      color: "text-orange-600",  bg: "bg-orange-50 border-orange-200" };
+  if (vdot >= 50) return { label: "Competitive",   color: "text-yellow-600",  bg: "bg-yellow-50 border-yellow-200" };
+  if (vdot >= 40) return { label: "Intermediate",  color: "text-blue-600",    bg: "bg-blue-50 border-blue-200"   };
+  if (vdot >= 30) return { label: "Recreational",  color: "text-emerald-600", bg: "bg-emerald-50 border-emerald-200" };
+  return             { label: "Beginner",       color: "text-gray-600",    bg: "bg-gray-50 border-gray-200"   };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function fmtSeconds(total: number): string {
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const mm = m.toString().padStart(2, "0");
+  const ss = s.toString().padStart(2, "0");
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+// ─── Props ───────────────────────────────────────────────────────────────────
 
 interface RaceDetailsFormProps {
   inputs: PaceInputs;
   errors: FormErrors;
   onInputChange: (e: { target: { name: string; value: string } }) => void;
-  onPresetClick: (distance: number) => void;
+  /** distance in km + preset name so parent can track selected preset */
+  onPresetClick: (distance: number, presetName: string) => void;
   onCalculate: () => void;
   isCalculating: boolean;
+  /** Name of the currently selected preset (e.g. "Marathon") */
+  selectedPresetName?: string | null;
+  /** Live VDOT derived from current inputs – null when inputs are incomplete */
+  liveVdot?: number | null;
+  /** Called when user taps a suggested finishing-time chip */
+  onSuggestedTimeClick?: (h: string, m: string, s: string) => void;
+  /** Called when slider is dragged – parent updates h/m/s from totalSeconds */
+  onSliderChange?: (totalSeconds: number) => void;
 }
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 export function RaceDetailsForm({
   inputs,
@@ -30,200 +80,255 @@ export function RaceDetailsForm({
   onPresetClick,
   onCalculate,
   isCalculating,
+  selectedPresetName,
+  liveVdot,
+  onSuggestedTimeClick,
+  onSliderChange,
 }: RaceDetailsFormProps) {
   const isKm = inputs.units === "km";
 
+  // Refs for auto-advance between HH/MM/SS fields
+  const minutesRef = useRef<HTMLInputElement>(null);
+  const secondsRef = useRef<HTMLInputElement>(null);
+
+  // Suggested times + slider config for the selected preset
+  const suggestedTimes = selectedPresetName ? (SUGGESTED_TIMES[selectedPresetName] ?? []) : [];
+  const sliderRange    = selectedPresetName ? (SLIDER_RANGES[selectedPresetName]    ?? null) : null;
+
+  // Derived totals
+  const currentTimeSeconds = timeToSeconds(inputs.hours, inputs.minutes, inputs.seconds);
+  const hasValidTime = currentTimeSeconds > 0;
+
+  // Which suggested chip (if any) matches current time
+  const activeChipLabel = hasValidTime
+    ? suggestedTimes.find((s) => timeToSeconds(s.hours, s.minutes, s.seconds) === currentTimeSeconds)?.label
+    : undefined;
+
+  // VDOT badge
+  const vdotLevel = liveVdot != null ? getVdotLevelLocal(liveVdot) : null;
+
+  // Clamp slider value to configured range
+  const sliderValue = sliderRange
+    ? Math.min(Math.max(currentTimeSeconds || sliderRange.min, sliderRange.min), sliderRange.max)
+    : 0;
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+
   const handleUnitToggle = () => {
     const newUnit = isKm ? "miles" : "km";
-
-    // Convert existing distance if there is one
     if (inputs.distance && !isNaN(parseFloat(inputs.distance))) {
-      const currentDistance = parseFloat(inputs.distance);
-      const convertedDistance = convertDistance(
-        currentDistance,
-        inputs.units,
-        newUnit
-      );
-
-      // Update both unit and converted distance
-      onInputChange({
-        target: {
-          name: "distance",
-          value: convertedDistance.toString(),
-        },
-      });
+      const converted = convertDistance(parseFloat(inputs.distance), inputs.units, newUnit);
+      onInputChange({ target: { name: "distance", value: converted.toString() } });
     }
-
-    // Update the unit
-    onInputChange({
-      target: {
-        name: "units",
-        value: newUnit,
-      },
-    });
+    onInputChange({ target: { name: "units", value: newUnit } });
   };
+
+  const handleTimeKeyUp = (e: React.KeyboardEvent<HTMLInputElement>, field: "hours" | "minutes") => {
+    if ((e.target as HTMLInputElement).value.length >= 2) {
+      if (field === "hours")   minutesRef.current?.focus();
+      if (field === "minutes") secondsRef.current?.focus();
+    }
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
     <Card className="bg-white shadow-lg">
-      <CardContent className="p-8 space-y-6">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-4">
-          Race Details
-        </h2>
+      <CardContent className="p-6 md:p-8 space-y-7">
+        <h2 className="text-2xl font-semibold text-gray-900">Race Details</h2>
 
-        {/* Preset Distances - Button Pills */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
-            Quick Select{" "}
-            <span className="text-gray-400 text-xs">(Optional)</span>
-          </label>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-            {PRESET_DISTANCES.map((preset) => (
-              <TooltipProvider key={preset.name}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      data-testid={`preset-${preset.name.toLowerCase().replace(/\s+/g, '-')}`}
-                      onClick={() => onPresetClick(preset.distance)}
-                      className={`py-4 px-2 text-sm sm:text-base font-semibold rounded-xl transition-all hover:scale-105 ${
-                        inputs.distance === preset.distance.toString()
-                          ? "bg-blue-600 text-white shadow-md"
-                          : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                      }`}
-                    >
-                      {preset.name}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{preset.distance} km</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ))}
+        {/* ── 1. Distance presets ── */}
+        <div className="space-y-3">
+          <label className="block text-sm font-medium text-gray-700">Distance</label>
+
+          <div className="grid grid-cols-3 md:grid-cols-6 gap-2">
+            {PRESET_DISTANCES.map((preset) => {
+              const isSelected = inputs.distance === preset.distance.toString();
+              return (
+                <button
+                  key={preset.name}
+                  data-testid={`preset-${preset.name.toLowerCase().replace(/\s+/g, "-")}`}
+                  onClick={() => onPresetClick(preset.distance, preset.name)}
+                  className={`py-3 px-2 text-sm font-semibold rounded-xl transition-all hover:scale-105 ${
+                    isSelected
+                      ? "bg-blue-600 text-white shadow-md"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  }`}
+                >
+                  {preset.name}
+                </button>
+              );
+            })}
           </div>
-        </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {/* Distance Input */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Race Distance <span className="text-red-500">*</span>
-            </label>
-            <div className="flex items-center gap-2">
-              <input
-                type="number"
-                inputMode="decimal"
-                placeholder="Distance"
-                name="distance"
-                data-testid="pace-distance"
-                min="0"
-                max="250"
-                step="0.1"
-                value={inputs.distance}
-                onChange={onInputChange}
-                className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
-                  errors.distance ? "border-red-500" : "border-gray-300"
+          {/* Custom distance + unit toggle */}
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              inputMode="decimal"
+              placeholder="Custom distance"
+              name="distance"
+              data-testid="pace-distance"
+              min="0"
+              max="250"
+              step="0.1"
+              value={inputs.distance}
+              onChange={onInputChange}
+              className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+                errors.distance ? "border-red-500" : "border-gray-300"
+              }`}
+            />
+            <div
+              className="relative w-32 h-10 bg-blue-100 rounded-full cursor-pointer overflow-hidden flex-shrink-0"
+              onClick={handleUnitToggle}
+            >
+              <div
+                className={`absolute top-1 left-1 w-[calc(50%-0.25rem)] h-8 bg-blue-600 rounded-full shadow-md transform transition-transform duration-300 ease-in-out ${
+                  !isKm ? "translate-x-full" : "translate-x-0"
                 }`}
               />
-              <div
-                className="relative w-32 h-10 bg-blue-100 rounded-full cursor-pointer overflow-hidden"
-                onClick={handleUnitToggle}
-              >
-                <div
-                  className={`absolute top-1 left-1 w-[calc(50%-0.25rem)] h-8 bg-blue-600 rounded-full shadow-md transform transition-transform duration-300 ease-in-out ${
-                    !isKm ? "translate-x-full" : "translate-x-0"
-                  }`}
-                />
-                <div className="absolute inset-0 flex items-center">
-                  <div
-                    className={`w-1/2 text-center text-sm font-medium transition-colors ${
-                      isKm ? "text-white" : "text-blue-700"
-                    }`}
-                  >
-                    KM
-                  </div>
-                  <div
-                    className={`w-1/2 text-center text-sm font-medium transition-colors ${
-                      !isKm ? "text-white" : "text-blue-700"
-                    }`}
-                  >
-                    MI
-                  </div>
-                </div>
+              <div className="absolute inset-0 flex items-center">
+                <div className={`w-1/2 text-center text-sm font-medium transition-colors ${isKm ? "text-white" : "text-blue-700"}`}>KM</div>
+                <div className={`w-1/2 text-center text-sm font-medium transition-colors ${!isKm ? "text-white" : "text-blue-700"}`}>MI</div>
               </div>
             </div>
-            {errors.distance && (
-              <p className="text-red-500 text-sm mt-1">{errors.distance}</p>
-            )}
           </div>
-
-          {/* Time Input */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Finish Time <span className="text-red-500">*</span>
-            </label>
-            <div className="flex items-center gap-2">
-              <input
-                type="number"
-                inputMode="tel"
-                placeholder="HH"
-                name="hours"
-                data-testid="pace-hours"
-                min="0"
-                max="99"
-                value={inputs.hours}
-                onChange={onInputChange}
-                className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-center ${
-                  errors.time ? "border-red-500" : "border-gray-300"
-                }`}
-              />
-              <span className="text-gray-400 font-medium">:</span>
-              <input
-                type="number"
-                inputMode="tel"
-                placeholder="MM"
-                name="minutes"
-                data-testid="pace-minutes"
-                min="0"
-                max="59"
-                value={inputs.minutes}
-                onChange={onInputChange}
-                className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-center ${
-                  errors.time ? "border-red-500" : "border-gray-300"
-                }`}
-              />
-              <span className="text-gray-400 font-medium">:</span>
-              <input
-                type="number"
-                inputMode="tel"
-                placeholder="SS"
-                name="seconds"
-                data-testid="pace-seconds"
-                min="0"
-                max="59"
-                value={inputs.seconds}
-                onChange={onInputChange}
-                className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-center ${
-                  errors.time ? "border-red-500" : "border-gray-300"
-                }`}
-              />
-            </div>
-            {errors.time && (
-              <p className="text-red-500 text-sm mt-1">{errors.time}</p>
-            )}
-          </div>
+          {errors.distance && <p className="text-red-500 text-sm">{errors.distance}</p>}
         </div>
 
-        {/* Optional Fields Section */}
-        <div className="pt-6 border-t border-gray-200">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">
-            Optional Adjustments{" "}
-            <span className="text-gray-400 text-xs font-normal">
-              (for more personalized results)
-            </span>
-          </h3>
+        {/* ── 2. Suggested finishing times (contextual) ── */}
+        {suggestedTimes.length > 0 && (
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">
+              Common finishing times
+            </label>
+            <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-none">
+              {suggestedTimes.map((s) => {
+                const isActive = activeChipLabel === s.label;
+                return (
+                  <button
+                    key={s.label}
+                    onClick={() => onSuggestedTimeClick?.(s.hours, s.minutes, s.seconds)}
+                    className={`flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium border transition-all ${
+                      isActive
+                        ? "bg-blue-600 text-white border-blue-600 shadow"
+                        : "bg-white text-gray-700 border-gray-200 hover:border-blue-400 hover:text-blue-600"
+                    }`}
+                  >
+                    {s.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {/* Age Input for Heart Rate Zones */}
+        {/* ── 3. Time input (HH : MM : SS) ── */}
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">
+            Finish Time <span className="text-red-500">*</span>
+          </label>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              inputMode="tel"
+              placeholder="HH"
+              name="hours"
+              data-testid="pace-hours"
+              min="0"
+              max="99"
+              value={inputs.hours}
+              onChange={onInputChange}
+              onKeyUp={(e) => handleTimeKeyUp(e, "hours")}
+              className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-center ${
+                errors.time ? "border-red-500" : "border-gray-300"
+              }`}
+            />
+            <span className="text-gray-400 font-medium text-xl select-none">:</span>
+            <input
+              ref={minutesRef}
+              type="number"
+              inputMode="tel"
+              placeholder="MM"
+              name="minutes"
+              data-testid="pace-minutes"
+              min="0"
+              max="59"
+              value={inputs.minutes}
+              onChange={onInputChange}
+              onKeyUp={(e) => handleTimeKeyUp(e, "minutes")}
+              className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-center ${
+                errors.time ? "border-red-500" : "border-gray-300"
+              }`}
+            />
+            <span className="text-gray-400 font-medium text-xl select-none">:</span>
+            <input
+              ref={secondsRef}
+              type="number"
+              inputMode="tel"
+              placeholder="SS"
+              name="seconds"
+              data-testid="pace-seconds"
+              min="0"
+              max="59"
+              value={inputs.seconds}
+              onChange={onInputChange}
+              className={`flex-1 px-4 py-3 text-lg border rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-center ${
+                errors.time ? "border-red-500" : "border-gray-300"
+              }`}
+            />
+          </div>
+          {errors.time && <p className="text-red-500 text-sm">{errors.time}</p>}
+        </div>
+
+        {/* ── 4. Fine-tune slider (preset distances only, after time is entered) ── */}
+        {sliderRange && hasValidTime && (
+          <div className="bg-gray-50 rounded-2xl p-4 space-y-3 border border-gray-100">
+            <div className="flex items-center justify-between text-xs text-gray-500">
+              <span>Faster</span>
+              <span className="font-semibold text-gray-800 text-sm tabular-nums">
+                {fmtSeconds(currentTimeSeconds)}
+              </span>
+              <span>Slower</span>
+            </div>
+
+            <input
+              type="range"
+              min={sliderRange.min}
+              max={sliderRange.max}
+              step={sliderRange.step}
+              value={sliderValue}
+              onChange={(e) => onSliderChange?.(parseInt(e.target.value, 10))}
+              className="w-full h-2 bg-gray-200 rounded-full appearance-none cursor-pointer accent-blue-600
+                [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-5
+                [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-600
+                [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:shadow-md"
+            />
+
+            <div className="flex justify-between text-[11px] text-gray-400 tabular-nums">
+              <span>{fmtSeconds(sliderRange.min)}</span>
+              <span>{fmtSeconds(sliderRange.max)}</span>
+            </div>
+          </div>
+        )}
+
+        {/* ── 5. Live VDOT badge ── */}
+        {liveVdot != null && vdotLevel != null && (
+          <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border text-sm font-semibold ${vdotLevel.bg} ${vdotLevel.color}`}>
+            <Zap className="w-4 h-4" />
+            VDOT {liveVdot} · {vdotLevel.label}
+          </div>
+        )}
+
+        {/* ── 6. Optional adjustments ── */}
+        <div className="pt-4 border-t border-gray-100 space-y-4">
+          <p className="text-sm font-semibold text-gray-900">
+            Optional{" "}
+            <span className="font-normal text-gray-400 text-xs">for more personalised results</span>
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 Age{" "}
@@ -251,7 +356,6 @@ export function RaceDetailsForm({
               />
             </div>
 
-            {/* Temperature Input for Weather Adjustments */}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 Temperature (°F){" "}
@@ -281,13 +385,14 @@ export function RaceDetailsForm({
           </div>
         </div>
 
+        {/* ── CTA ── */}
         <button
           onClick={onCalculate}
           disabled={isCalculating}
           data-testid="pace-calculate"
-          className="w-full py-4 text-lg font-semibold text-white bg-blue-600 rounded-xl hover:bg-blue-700 transition-colors shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full py-4 text-lg font-semibold text-white bg-blue-600 rounded-xl hover:bg-blue-700 active:bg-blue-800 transition-colors shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {isCalculating ? "Calculating..." : "Calculate Training Paces"}
+          {isCalculating ? "Calculating…" : "Calculate Training Paces"}
         </button>
       </CardContent>
     </Card>

--- a/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
+++ b/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
@@ -11,7 +11,8 @@
  */
 
 import { useRef } from "react";
-import { Zap } from "lucide-react";
+import { Zap, ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Tooltip,
@@ -313,12 +314,17 @@ export function RaceDetailsForm({
           </div>
         )}
 
-        {/* ── 5. Live VDOT badge ── */}
+        {/* ── 5. Live VDOT badge — links to full VDOT analysis ── */}
         {liveVdot != null && vdotLevel != null && (
-          <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border text-sm font-semibold ${vdotLevel.bg} ${vdotLevel.color}`}>
+          <Link
+            to="/vdot"
+            title="Open full VDOT analysis"
+            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border text-sm font-semibold transition-opacity hover:opacity-80 ${vdotLevel.bg} ${vdotLevel.color}`}
+          >
             <Zap className="w-4 h-4" />
             VDOT {liveVdot} · {vdotLevel.label}
-          </div>
+            <ArrowRight className="w-3.5 h-3.5 ml-0.5 opacity-60" />
+          </Link>
         )}
 
         {/* ── 6. Optional adjustments ── */}

--- a/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
+++ b/vite-project/src/features/pace-calculator/components/RaceDetailsForm.tsx
@@ -165,6 +165,7 @@ export function RaceDetailsForm({
           </div>
 
           {/* Custom distance + unit toggle */}
+          <p className="text-xs text-gray-400">or enter a custom distance</p>
           <div className="flex items-center gap-2">
             <input
               type="number"
@@ -206,7 +207,7 @@ export function RaceDetailsForm({
             <label className="block text-sm font-medium text-gray-700">
               Common finishing times
             </label>
-            <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-none">
+            <div className="flex flex-wrap gap-2">
               {suggestedTimes.map((s) => {
                 const isActive = activeChipLabel === s.label;
                 return (
@@ -322,7 +323,7 @@ export function RaceDetailsForm({
           <Link
             to="/vdot"
             title="Open full VDOT analysis"
-            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border text-sm font-semibold transition-opacity hover:opacity-80 ${vdotLevel.bg} ${vdotLevel.color}`}
+            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border text-sm font-semibold cursor-pointer transition-all hover:shadow-md hover:scale-[1.02] ${vdotLevel.bg} ${vdotLevel.color}`}
           >
             <Zap className="w-4 h-4" />
             VDOT {liveVdot} · {vdotLevel.label}

--- a/vite-project/src/features/pace-calculator/types.ts
+++ b/vite-project/src/features/pace-calculator/types.ts
@@ -11,6 +11,68 @@ export const PRESET_DISTANCES = [
   { name: "800m", distance: 0.8 },
 ] as const;
 
+export type SuggestedTime = {
+  label: string;
+  hours: string;
+  minutes: string;
+  seconds: string;
+};
+
+/** Common finishing times shown as quick-select chips per distance */
+export const SUGGESTED_TIMES: Record<string, SuggestedTime[]> = {
+  "Marathon": [
+    { label: "Sub 3h", hours: "2", minutes: "59", seconds: "00" },
+    { label: "3:15", hours: "3", minutes: "15", seconds: "00" },
+    { label: "3:30", hours: "3", minutes: "30", seconds: "00" },
+    { label: "4:00", hours: "4", minutes: "00", seconds: "00" },
+    { label: "4:30", hours: "4", minutes: "30", seconds: "00" },
+    { label: "5:00", hours: "5", minutes: "00", seconds: "00" },
+  ],
+  "Half Marathon": [
+    { label: "Sub 1:30", hours: "1", minutes: "29", seconds: "00" },
+    { label: "1:45", hours: "1", minutes: "45", seconds: "00" },
+    { label: "2:00", hours: "2", minutes: "00", seconds: "00" },
+    { label: "2:15", hours: "2", minutes: "15", seconds: "00" },
+    { label: "2:30", hours: "2", minutes: "30", seconds: "00" },
+  ],
+  "10K": [
+    { label: "Sub 40", hours: "0", minutes: "39", seconds: "59" },
+    { label: "45:00", hours: "0", minutes: "45", seconds: "00" },
+    { label: "50:00", hours: "0", minutes: "50", seconds: "00" },
+    { label: "55:00", hours: "0", minutes: "55", seconds: "00" },
+    { label: "1:00:00", hours: "1", minutes: "00", seconds: "00" },
+  ],
+  "5K": [
+    { label: "Sub 20", hours: "0", minutes: "19", seconds: "59" },
+    { label: "22:00", hours: "0", minutes: "22", seconds: "00" },
+    { label: "25:00", hours: "0", minutes: "25", seconds: "00" },
+    { label: "28:00", hours: "0", minutes: "28", seconds: "00" },
+    { label: "30:00", hours: "0", minutes: "30", seconds: "00" },
+  ],
+  "1K": [
+    { label: "3:30", hours: "0", minutes: "3", seconds: "30" },
+    { label: "4:00", hours: "0", minutes: "4", seconds: "00" },
+    { label: "4:30", hours: "0", minutes: "4", seconds: "30" },
+    { label: "5:00", hours: "0", minutes: "5", seconds: "00" },
+  ],
+  "800m": [
+    { label: "2:30", hours: "0", minutes: "2", seconds: "30" },
+    { label: "3:00", hours: "0", minutes: "3", seconds: "00" },
+    { label: "3:30", hours: "0", minutes: "3", seconds: "30" },
+    { label: "4:00", hours: "0", minutes: "4", seconds: "00" },
+  ],
+};
+
+/** Slider min/max/step in seconds per distance preset */
+export const SLIDER_RANGES: Record<string, { min: number; max: number; step: number }> = {
+  "Marathon":      { min: 7200,  max: 25200, step: 30 },  // 2:00:00 – 7:00:00
+  "Half Marathon": { min: 3600,  max: 12600, step: 30 },  // 1:00:00 – 3:30:00
+  "10K":           { min: 1500,  max: 5400,  step: 15 },  // 25:00 – 1:30:00
+  "5K":            { min: 720,   max: 2700,  step: 5  },  // 12:00 – 45:00
+  "1K":            { min: 150,   max: 600,   step: 5  },  // 2:30 – 10:00
+  "800m":          { min: 120,   max: 480,   step: 5  },  // 2:00 – 8:00
+};
+
 export type DistanceUnit = "km" | "miles";
 export type PaceUnit = "km" | "Miles";
 


### PR DESCRIPTION
- Add SUGGESTED_TIMES: contextual goal-time chips per distance preset
  (e.g. "Sub 3h", "3:30", "4:00" for Marathon) that instantly populate
  the HH:MM:SS fields and auto-calculate training paces on tap
- Add SLIDER_RANGES: per-distance min/max/step config for the fine-tune
  slider (Marathon 2h–7h, 5K 12min–45min, etc.)
- Add live VDOT badge (⚡ VDOT 45.2 · Intermediate) that updates as the
  user types or drags the slider – powered by Jack Daniels' formula
- Add fine-tune slider that appears after a preset distance is chosen and
  a valid time is entered; dragging updates HH/MM/SS fields in real time
- Auto-advance focus HH → MM → SS after 2 digits for faster entry
- Auto-calculate when a suggested-time chip is tapped (no button press needed)
- Track selectedPresetName in PaceCalculatorV2 so chips + slider are
  contextually shown only for known race distances

https://claude.ai/code/session_011ty7rQtakAjWbks15dqSXE