### PR TITLE
Add human-readable, editable URLs for uploaded elevation routes

### DIFF
--- a/vite-project/src/components/elevationfinder/GpxUploader.tsx
+++ b/vite-project/src/components/elevationfinder/GpxUploader.tsx
@@ -22,6 +22,12 @@ import {
 import { storage, db } from "../../lib/firebase";
 import { useAuth } from "../../features/auth/AuthContext";
 import { processGPXUpload } from "../../lib/gpxMetaData";
+import {
+  slugify,
+  generateShortId,
+  buildRouteSlugPath,
+  buildRouteUrl,
+} from "../../lib/routeSlug";
 
 interface GpxUploaderProps {
   onFileParsed: (
@@ -45,6 +51,7 @@ interface DuplicateFile {
   content?: string; // Optional: content stored in Firestore
   storageRef?: string; // Storage reference path
   docId?: string; // Firestore document ID
+  displayUrl?: string; // Pretty /elevationfinder/{slug}-{shortId} path
 }
 
 export default function GpxUploader({
@@ -110,6 +117,7 @@ export default function GpxUploader({
           content: data.content, // Include content if stored
           storageRef: data.storageRef,
           docId: duplicateDoc.id, // Include document ID for reference
+          displayUrl: data.displayUrl, // Pretty URL if the doc has one
         };
       }
 
@@ -227,6 +235,7 @@ export default function GpxUploader({
     fileUrl: string;
     displayPoints: Array<{ lat: number; lng: number; ele?: number }>;
     docId: string; // Return docId for immediate caching
+    displayUrl: string; // Pretty /elevationfinder/{slug}-{shortId} path
   }> => {
     const safeFilename = generateSafeFilename(file.name);
     const storageRef = ref(storage, `gpx_files/${safeFilename}`);
@@ -250,7 +259,14 @@ export default function GpxUploader({
       // Create document with random ID
       const docRef = doc(collection(db, "gpx_uploads"));
       const docId = docRef.id;
-      const displayUrl = `/elevationfinder/${docId}`;
+
+      // Human-readable shareable URL: /elevationfinder/{slug}-{shortId}.
+      // The slug is derived from the filename (owner-editable later); the
+      // shortId is the immutable resolution key so renaming never breaks links.
+      const slug = slugify(file.name);
+      const shortId = generateShortId();
+      const slugPath = buildRouteSlugPath(slug, shortId);
+      const displayUrl = buildRouteUrl(slugPath);
 
       const docData = {
         userId: user?.uid,
@@ -267,6 +283,8 @@ export default function GpxUploader({
         displayPoints: processed.displayPoints,
         thumbnailPoints: processed.thumbnailPoints,
         docId,
+        slug,
+        shortId,
         displayUrl,
 
         // 🚀 NEW: Prepare for optimized caching (will be populated by API)
@@ -286,6 +304,7 @@ export default function GpxUploader({
         fileUrl: downloadURL,
         displayPoints: processed.displayPoints,
         docId, // Return docId so ElevationPage can cache analysis immediately
+        displayUrl, // Pretty URL so the address bar + share use the slug path
       };
     } catch (error) {
       console.error("Upload failed:", error);
@@ -322,7 +341,9 @@ export default function GpxUploader({
           duplicateFound.content,
           filename,
           fileUrl,
-          duplicateFound.docId || null
+          duplicateFound.docId || null,
+          undefined,
+          duplicateFound.displayUrl
         );
         return;
       }
@@ -339,7 +360,14 @@ export default function GpxUploader({
         }
 
         const content = await response.text();
-        onFileParsed(content, filename, freshUrl, duplicateFound.docId || null);
+        onFileParsed(
+          content,
+          filename,
+          freshUrl,
+          duplicateFound.docId || null,
+          undefined,
+          duplicateFound.displayUrl
+        );
         return;
       }
 
@@ -352,6 +380,12 @@ export default function GpxUploader({
       const content = await response.text();
       const processed = processGPXUpload(content);
 
+      // Build a pretty shareable URL for the fallback document too.
+      const slug = slugify(filename);
+      const shortId = generateShortId();
+      const slugPath = buildRouteSlugPath(slug, shortId);
+      const displayUrl = buildRouteUrl(slugPath);
+
       // Create new document for fallback case
       const docRef = await addDoc(collection(db, "gpx_uploads"), {
         filename,
@@ -361,11 +395,13 @@ export default function GpxUploader({
         fileUrl,
         displayPoints: processed.displayPoints,
         metadata: processed.metadata,
+        slug,
+        shortId,
+        displayUrl,
         staticRouteData: null,
       });
 
       const docId = docRef.id;
-      const displayUrl = `/elevationfinder/${docId}`;
 
       onFileParsed(
         content,
@@ -454,19 +490,16 @@ export default function GpxUploader({
       setUploadProgress(60);
 
       // Upload to Firebase
-      const { fileUrl, displayPoints, docId } = await uploadToFirebase(
-        file,
-        content,
-        fileHash
-      );
+      const { fileUrl, displayPoints, docId, displayUrl } =
+        await uploadToFirebase(file, content, fileHash);
       setUploadProgress(85);
 
       // Update rate limit counters
       await checkRateLimits();
       setUploadProgress(100);
 
-      // 🚀 NEW: Pass docId to enable immediate caching
-      onFileParsed(content, file.name, fileUrl, docId, displayPoints);
+      // 🚀 NEW: Pass docId to enable immediate caching + the pretty displayUrl
+      onFileParsed(content, file.name, fileUrl, docId, displayPoints, displayUrl);
 
       toast({
         title: "Upload Successful",

--- a/vite-project/src/components/ui/ShareButton.tsx
+++ b/vite-project/src/components/ui/ShareButton.tsx
@@ -12,13 +12,17 @@ import {
 import { ShareLinkBox } from "@/components/ui/ShareLinkBox";
 
 interface ShareButtonProps {
-  docId: string;
+  /** Pretty path segment, e.g. "boston-marathon-a3f9c". Preferred. */
+  path?: string;
+  /** Legacy fallback: raw Firestore doc id. */
+  docId?: string;
   variant?: "default" | "outline" | "ghost";
   size?: "default" | "sm" | "lg" | "icon";
   className?: string;
 }
 
 export function ShareButton({
+  path,
   docId,
   variant = "outline",
   size = "default",
@@ -41,7 +45,7 @@ export function ShareButton({
             Anyone with this link can view your route analysis.
           </DialogDescription>
         </DialogHeader>
-        <ShareLinkBox docId={docId} />
+        <ShareLinkBox path={path} docId={docId} />
       </DialogContent>
     </Dialog>
   );

--- a/vite-project/src/components/ui/ShareLinkBox.tsx
+++ b/vite-project/src/components/ui/ShareLinkBox.tsx
@@ -5,16 +5,17 @@ import { Copy, Facebook, Twitter } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface ShareLinkBoxProps {
-  docId: string;
+  /** Pretty path segment, e.g. "boston-marathon-a3f9c". Preferred. */
+  path?: string;
+  /** Legacy fallback: raw Firestore doc id. */
+  docId?: string;
   className?: string;
 }
 
-export function ShareLinkBox({ docId, className }: ShareLinkBoxProps) {
+export function ShareLinkBox({ path, docId, className }: ShareLinkBoxProps) {
   const { toast } = useToast();
-  const shareUrl = `https://www.trainpace.com/elevationfinder/${docId}`;
-
-  // Debug log
-  console.log('ShareLinkBox received docId:', docId);
+  const segment = path || docId || "";
+  const shareUrl = `https://www.trainpace.com/elevationfinder/${segment}`;
 
   const handleCopy = async () => {
     try {

--- a/vite-project/src/features/dashboard/actions.ts
+++ b/vite-project/src/features/dashboard/actions.ts
@@ -5,7 +5,58 @@ import {
   deleteDoc,
 } from "firebase/firestore";
 import { db } from "../../lib/firebase";
+import {
+  slugify,
+  generateShortId,
+  buildRouteSlugPath,
+  buildRouteUrl,
+} from "../../lib/routeSlug";
 import { FuelPlan, PacePlan } from "./types";
+
+/**
+ * Update the editable URL slug of an uploaded route. The immutable shortId is
+ * preserved (or generated for legacy routes that predate slugs) so existing
+ * shared links keep resolving while the slug part of the URL changes.
+ * Returns the new slug / shortId / displayUrl for optimistic local updates.
+ */
+export async function updateRouteSlug(
+  userId: string,
+  routeId: string,
+  desiredSlug: string
+): Promise<{ slug: string; shortId: string; displayUrl: string }> {
+  const slug = slugify(desiredSlug);
+  if (!slug) {
+    throw new Error("Please enter a URL with at least one letter or number");
+  }
+
+  const docRef = doc(db, "gpx_uploads", routeId);
+  const docSnap = await getDoc(docRef);
+  if (!docSnap.exists()) {
+    throw new Error("Route does not exist");
+  }
+
+  const data = docSnap.data();
+  if (!data.userId || data.userId !== userId) {
+    throw new Error("You are not authorized to edit this route");
+  }
+
+  // Keep the existing resolution token; mint one for legacy routes.
+  const shortId: string =
+    typeof data.shortId === "string" && data.shortId.length > 0
+      ? data.shortId
+      : generateShortId();
+
+  const displayUrl = buildRouteUrl(buildRouteSlugPath(slug, shortId));
+
+  await updateDoc(docRef, {
+    slug,
+    shortId,
+    displayUrl,
+    updatedAt: Date.now(),
+  });
+
+  return { slug, shortId, displayUrl };
+}
 
 export async function deleteRoute(
   userId: string,

--- a/vite-project/src/features/dashboard/components/RouteCard.tsx
+++ b/vite-project/src/features/dashboard/components/RouteCard.tsx
@@ -8,19 +8,25 @@ import {
   Eye,
   Bookmark,
   AlertTriangle,
+  Link2,
 } from "lucide-react";
 import { Timestamp } from "firebase/firestore";
 import { RouteMetadata } from "../types";
+import { slugify, buildRouteSlugPath } from "../../../lib/routeSlug";
 import MapboxRoutePreview from "../../../components/utils/MapboxRoutePreview";
 
 interface RouteCardProps {
   route: RouteMetadata;
   onDelete: (routeId: string, routeType: "uploaded" | "bookmarked") => void;
+  onEditSlug?: (routeId: string, newSlug: string) => Promise<void>;
 }
 
-export function RouteCard({ route, onDelete }: RouteCardProps) {
+export function RouteCard({ route, onDelete, onEditSlug }: RouteCardProps) {
   const [showPreview, setShowPreview] = useState(true);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [editingUrl, setEditingUrl] = useState(false);
+  const [slugInput, setSlugInput] = useState("");
+  const [savingSlug, setSavingSlug] = useState(false);
   const isBookmarked = route.type === "bookmarked";
   const needsMigration =
     isBookmarked && (!route.routeKey || (route.schemaVersion || 1) < 2);
@@ -36,7 +42,9 @@ export function RouteCard({ route, onDelete }: RouteCardProps) {
 
   const getRouteLink = () => {
     if (route.type === "uploaded") {
-      return `/elevationfinder/${route.id}`;
+      // Prefer the pretty /elevationfinder/{slug}-{shortId} URL; fall back to
+      // the raw doc id for legacy routes uploaded before slugs existed.
+      return route.displayUrl || `/elevationfinder/${route.id}`;
     } else {
       if (route.routeSlug) {
         return `/elevationfinder/${route.routeSlug}`;
@@ -48,6 +56,40 @@ export function RouteCard({ route, onDelete }: RouteCardProps) {
   const handleDelete = () => {
     onDelete(route.id, route.type);
     setDeleteConfirm(false);
+  };
+
+  // Default the editor to the current slug, falling back to a slug derived from
+  // the route/file name for legacy routes that never had one.
+  const currentSlug =
+    route.slug || slugify(route.filename || route.metadata?.routeName || "");
+
+  const previewSlug = slugify(slugInput);
+  const previewPath = buildRouteSlugPath(
+    previewSlug,
+    route.shortId || "xxxxxx"
+  );
+
+  const openEditUrl = () => {
+    setSlugInput(currentSlug);
+    setEditingUrl(true);
+  };
+
+  const handleSaveSlug = async () => {
+    if (!onEditSlug) return;
+    const cleaned = slugify(slugInput);
+    if (!cleaned || cleaned === route.slug) {
+      setEditingUrl(false);
+      return;
+    }
+    setSavingSlug(true);
+    try {
+      await onEditSlug(route.id, cleaned);
+      setEditingUrl(false);
+    } catch {
+      // Parent surfaces the error toast; keep the dialog open to retry.
+    } finally {
+      setSavingSlug(false);
+    }
   };
 
   return (
@@ -174,9 +216,80 @@ export function RouteCard({ route, onDelete }: RouteCardProps) {
                 {route.type === "uploaded" ? "View Upload" : "View Preview"}
               </span>
             </Link>
+            {route.type === "uploaded" && onEditSlug && (
+              <button
+                onClick={openEditUrl}
+                className="text-sm py-2 px-3 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors flex items-center justify-center space-x-1"
+                title="Edit shareable URL"
+                aria-label="Edit shareable URL"
+              >
+                <Link2 className="w-4 h-4" />
+                <span className="hidden sm:inline">Edit URL</span>
+              </button>
+            )}
           </div>
         </div>
       </div>
+
+      {/* Edit URL Modal */}
+      {editingUrl && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-lg max-w-md w-full mx-4">
+            <div className="flex items-center space-x-2 mb-2">
+              <Link2 className="w-5 h-5 text-emerald-600" />
+              <h3 className="text-lg font-semibold">Edit Shareable URL</h3>
+            </div>
+            <p className="text-gray-600 text-sm mb-4">
+              Choose a friendly URL for this route. The short code at the end
+              keeps existing shared links working.
+            </p>
+
+            <label
+              htmlFor={`slug-${route.id}`}
+              className="block text-xs font-medium text-gray-500 mb-1"
+            >
+              URL slug
+            </label>
+            <input
+              id={`slug-${route.id}`}
+              type="text"
+              value={slugInput}
+              onChange={(e) => setSlugInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSaveSlug();
+                if (e.key === "Escape") setEditingUrl(false);
+              }}
+              placeholder="boston-marathon"
+              autoFocus
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+
+            <div className="mt-2 text-xs text-gray-500 break-all">
+              Preview:{" "}
+              <span className="text-gray-700">
+                trainpace.com/elevationfinder/{previewPath}
+              </span>
+            </div>
+
+            <div className="flex gap-3 justify-end mt-6">
+              <button
+                onClick={() => setEditingUrl(false)}
+                disabled={savingSlug}
+                className="px-4 py-2 bg-white text-black rounded outline-none border border-gray-300 hover:bg-gray-100 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSaveSlug}
+                disabled={savingSlug || !previewSlug}
+                className="px-4 py-2 bg-emerald-500 text-white rounded hover:bg-emerald-600 disabled:opacity-50"
+              >
+                {savingSlug ? "Saving…" : "Save URL"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Delete Confirmation Modal */}
       {deleteConfirm && (

--- a/vite-project/src/features/dashboard/components/RoutesSection.tsx
+++ b/vite-project/src/features/dashboard/components/RoutesSection.tsx
@@ -7,6 +7,7 @@ interface RoutesSectionProps {
   routes: RouteMetadata[];
   loading: boolean;
   onDeleteRoute: (routeId: string, routeType: "uploaded" | "bookmarked") => void;
+  onEditSlug?: (routeId: string, newSlug: string) => Promise<void>;
 }
 
 const ROUTES_PER_PAGE = 6; // 2 rows of 3 cards max - keeps WebGL contexts low
@@ -15,6 +16,7 @@ export function RoutesSection({
   routes,
   loading,
   onDeleteRoute,
+  onEditSlug,
 }: RoutesSectionProps) {
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -94,7 +96,12 @@ export function RoutesSection({
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {currentRoutes.map((route) => (
-          <RouteCard key={route.id} route={route} onDelete={onDeleteRoute} />
+          <RouteCard
+            key={route.id}
+            route={route}
+            onDelete={onDeleteRoute}
+            onEditSlug={onEditSlug}
+          />
         ))}
       </div>
 

--- a/vite-project/src/features/dashboard/hooks/useRoutes.ts
+++ b/vite-project/src/features/dashboard/hooks/useRoutes.ts
@@ -54,6 +54,8 @@ export function useRoutes(userId: string | undefined) {
           uploadedAt: data.uploadedAt,
           metadata: data.metadata,
           thumbnailPoints: data.thumbnailPoints || [],
+          slug: data.slug,
+          shortId: data.shortId,
           displayUrl: data.displayUrl,
           fileUrl: data.fileUrl,
         });
@@ -112,5 +114,20 @@ export function useRoutes(userId: string | undefined) {
     setRoutes((prev) => prev.filter((route) => route.id !== routeId));
   };
 
-  return { routes, loading, error, reload: loadRoutes, removeRoute };
+  const updateRoute = (routeId: string, patch: Partial<RouteMetadata>) => {
+    setRoutes((prev) =>
+      prev.map((route) =>
+        route.id === routeId ? { ...route, ...patch } : route
+      )
+    );
+  };
+
+  return {
+    routes,
+    loading,
+    error,
+    reload: loadRoutes,
+    removeRoute,
+    updateRoute,
+  };
 }

--- a/vite-project/src/features/dashboard/index.ts
+++ b/vite-project/src/features/dashboard/index.ts
@@ -22,6 +22,7 @@ export {
   deleteFuelPlan,
   deletePacePlan,
   updatePacePlan,
+  updateRouteSlug,
   copyFuelPlanToClipboard,
   copyPacePlanToClipboard,
 } from "./actions";

--- a/vite-project/src/features/dashboard/types.ts
+++ b/vite-project/src/features/dashboard/types.ts
@@ -8,6 +8,8 @@ export interface RouteMetadata {
   routeSlug?: string; // For bookmarked routes (legacy)
   routeKey?: string; // For bookmarked routes (new)
   routeName?: string; // For bookmarked routes
+  slug?: string; // For uploaded routes: editable URL slug
+  shortId?: string; // For uploaded routes: immutable URL resolution token
   uploadedAt?: Timestamp | null;
   savedAt?: Timestamp | null; // For bookmarked routes
   schemaVersion?: number; // For migration tracking

--- a/vite-project/src/features/elevation/hooks/useFileUpload.ts
+++ b/vite-project/src/features/elevation/hooks/useFileUpload.ts
@@ -88,9 +88,13 @@ export function useFileUpload({
 
       setOriginalGpxText(gpxText);
 
-      // Update URL immediately after upload to enable sharing
-      if (docId) {
-        window.history.replaceState(null, "", `/elevationfinder/${docId}`);
+      // Update URL immediately after upload to enable sharing. Prefer the
+      // pretty /elevationfinder/{slug}-{shortId} path; fall back to the raw
+      // doc id only if the uploader didn't provide one.
+      const shareablePath =
+        displayUrl || (docId ? `/elevationfinder/${docId}` : null);
+      if (shareablePath) {
+        window.history.replaceState(null, "", shareablePath);
       }
 
       try {

--- a/vite-project/src/features/elevation/hooks/useRouteLoader.ts
+++ b/vite-project/src/features/elevation/hooks/useRouteLoader.ts
@@ -4,15 +4,60 @@
  */
 
 import { useState, useEffect } from "react";
-import { doc, getDoc } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  collection,
+  query,
+  where,
+  limit,
+  getDocs,
+} from "firebase/firestore";
 import { getDownloadURL, ref } from "firebase/storage";
 import { db, storage } from "@/lib/firebase";
+import { extractShortId } from "@/lib/routeSlug";
 import type {
   OptimizedRouteMetadata,
   GPXAnalysisResponse,
   AnalysisSettings,
   StaticRouteData,
 } from "../types";
+
+/**
+ * Resolve a URL param to its Firestore document. Pretty URLs of the form
+ * `{slug}-{shortId}` resolve on the trailing shortId (slug is cosmetic); legacy
+ * raw doc-id URLs (no hyphen) fall back to a direct document lookup so old
+ * shared links keep working.
+ */
+async function resolveRouteDoc(param: string): Promise<{
+  id: string;
+  data: OptimizedRouteMetadata;
+} | null> {
+  const shortId = extractShortId(param);
+
+  if (shortId) {
+    const q = query(
+      collection(db, "gpx_uploads"),
+      where("shortId", "==", shortId),
+      limit(1)
+    );
+    const snap = await getDocs(q);
+    if (!snap.empty) {
+      const docSnap = snap.docs[0];
+      return { id: docSnap.id, data: docSnap.data() as OptimizedRouteMetadata };
+    }
+  }
+
+  // Legacy raw doc id (or a pretty URL whose shortId no longer exists) —
+  // try a direct document lookup on the full param.
+  const docRef = doc(db, "gpx_uploads", param);
+  const docSnap = await getDoc(docRef);
+  if (docSnap.exists()) {
+    return { id: docSnap.id, data: docSnap.data() as OptimizedRouteMetadata };
+  }
+
+  return null;
+}
 
 interface UseRouteLoaderParams {
   routeId: string | undefined;
@@ -36,6 +81,9 @@ interface UseRouteLoaderReturn {
   originalGpxText: string | null;
   loading: boolean;
   error: string | null;
+  // The real Firestore document id the URL param resolved to (may differ from
+  // the param when a pretty `{slug}-{shortId}` URL was used).
+  resolvedDocId: string | null;
   setRouteMetadata: (metadata: OptimizedRouteMetadata | null) => void;
   setAnalysisData: (data: GPXAnalysisResponse | null) => void;
   setOriginalGpxText: (text: string | null) => void;
@@ -55,24 +103,31 @@ export function useRouteLoader({
   const [originalGpxText, setOriginalGpxText] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [resolvedDocId, setResolvedDocId] = useState<string | null>(null);
 
   useEffect(() => {
     const loadSharedRoute = async () => {
-      if (!routeId) return;
+      if (!routeId) {
+        setResolvedDocId(null);
+        return;
+      }
 
       setLoading(true);
       setError(null);
 
       try {
-        // 1. Load route metadata
-        const docRef = doc(db, "gpx_uploads", routeId);
-        const docSnap = await getDoc(docRef);
+        // 1. Resolve the URL param (pretty slug or legacy doc id) to its doc
+        const resolved = await resolveRouteDoc(routeId);
 
-        if (!docSnap.exists()) {
+        if (!resolved) {
           throw new Error("Shared route not found");
         }
 
-        const sharedData = docSnap.data() as OptimizedRouteMetadata;
+        // Always work against the real document id from here on, so caching,
+        // analysis, and ownership stay correct regardless of the URL slug.
+        const realDocId = resolved.id;
+        const sharedData = resolved.data;
+        setResolvedDocId(realDocId);
         setRouteMetadata(sharedData);
 
         // 2. Check if we have static data cached
@@ -81,7 +136,7 @@ export function useRouteLoader({
 
           // Check for cached analysis with current settings
           const cachedAnalysis = await getCachedAnalysis(
-            routeId,
+            realDocId,
             analysisSettings,
             sharedData.staticRouteData
           );
@@ -121,7 +176,7 @@ export function useRouteLoader({
           gpxText,
           analysisSettings,
           sharedData.filename,
-          routeId
+          realDocId
         );
 
         setAnalysisData(analysis);
@@ -142,6 +197,7 @@ export function useRouteLoader({
     originalGpxText,
     loading,
     error,
+    resolvedDocId,
     setRouteMetadata,
     setAnalysisData,
     setOriginalGpxText,

--- a/vite-project/src/lib/routeSlug.ts
+++ b/vite-project/src/lib/routeSlug.ts
@@ -1,0 +1,77 @@
+/**
+ * Route slug helpers for ElevationFinder shareable URLs.
+ *
+ * Uploaded routes use human-readable URLs of the form:
+ *   /elevationfinder/{slug}-{shortId}      e.g. /elevationfinder/boston-marathon-a3f9c
+ *
+ * - `slug`    — derived from the route/filename, freely editable by the owner.
+ * - `shortId` — an immutable lowercase base36 token, the real resolution key.
+ *
+ * The slug is purely cosmetic: routes always resolve on the trailing `shortId`,
+ * so renaming the slug never breaks an existing link. Legacy URLs that are a
+ * raw Firestore doc id (20 hyphen-free alphanumerics) keep working because the
+ * loader falls back to a direct document lookup when no shortId is present.
+ */
+
+const SHORT_ID_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Turn an arbitrary route name / filename into a URL-safe slug.
+ * Lowercases, drops a trailing `.gpx`, strips accents, and collapses any run
+ * of non-alphanumerics into single hyphens. Returns "" if nothing usable
+ * remains (callers fall back to a default via buildRouteSlugPath).
+ */
+export function slugify(input: string, maxLength = 60): string {
+  return input
+    .toLowerCase()
+    .replace(/\.gpx$/i, "")
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip accent marks
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, maxLength)
+    .replace(/-+$/g, "");
+}
+
+/**
+ * Generate a short, URL-safe, hyphen-free resolution token. 6 base36 chars
+ * gives ~2.2B combinations — collisions are astronomically unlikely at any
+ * realistic upload volume, and the alphabet guarantees no hyphens so the token
+ * is always the last hyphen-delimited segment of a slug path.
+ */
+export function generateShortId(length = 6): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += SHORT_ID_ALPHABET[bytes[i] % SHORT_ID_ALPHABET.length];
+  }
+  return out;
+}
+
+/**
+ * Build the `{slug}-{shortId}` path segment. Falls back to a "route" slug when
+ * the name produced no usable slug, so the result always contains a hyphen and
+ * is therefore always distinguishable from a legacy raw doc id.
+ */
+export function buildRouteSlugPath(slug: string, shortId: string): string {
+  const safeSlug = slug && slug.length > 0 ? slug : "route";
+  return `${safeSlug}-${shortId}`;
+}
+
+/** Full app path for a route slug segment. */
+export function buildRouteUrl(slugPath: string): string {
+  return `/elevationfinder/${slugPath}`;
+}
+
+/**
+ * Extract the resolution shortId from a URL param.
+ * Returns the segment after the final hyphen for pretty `{slug}-{shortId}`
+ * paths, or null when the param has no hyphen (a legacy raw doc id), in which
+ * case callers should resolve via a direct document lookup.
+ */
+export function extractShortId(param: string): string | null {
+  if (!param.includes("-")) return null;
+  const seg = param.slice(param.lastIndexOf("-") + 1);
+  return seg.length > 0 ? seg : null;
+}

--- a/vite-project/src/pages/DashboardV2.tsx
+++ b/vite-project/src/pages/DashboardV2.tsx
@@ -18,6 +18,7 @@ import {
   deleteFuelPlan,
   deletePacePlan,
   updatePacePlan,
+  updateRouteSlug,
   copyFuelPlanToClipboard,
   copyPacePlanToClipboard,
   DashboardTab,
@@ -39,6 +40,7 @@ export default function DashboardV2() {
     loading: routesLoading,
     error: routesError,
     removeRoute,
+    updateRoute,
   } = useRoutes(user?.uid);
 
   const {
@@ -99,6 +101,32 @@ export default function DashboardV2() {
         description: "Failed to delete route",
         variant: "destructive",
       });
+    }
+  };
+
+  const handleEditSlug = async (routeId: string, newSlug: string) => {
+    if (!user) return;
+
+    try {
+      const { slug, shortId, displayUrl } = await updateRouteSlug(
+        user.uid,
+        routeId,
+        newSlug
+      );
+      updateRoute(routeId, { slug, shortId, displayUrl });
+      toast({
+        title: "URL updated",
+        description: "Your route's shareable link has been updated.",
+      });
+    } catch (err) {
+      console.error("Slug update failed:", err);
+      toast({
+        title: "Update failed",
+        description:
+          err instanceof Error ? err.message : "Failed to update the URL",
+        variant: "destructive",
+      });
+      throw err; // Let the card keep its dialog open on failure
     }
   };
 
@@ -304,6 +332,7 @@ export default function DashboardV2() {
           routes={filteredRoutes}
           loading={routesLoading}
           onDeleteRoute={handleDeleteRoute}
+          onEditSlug={handleEditSlug}
         />
       )}
 

--- a/vite-project/src/pages/ElevationPageV2.tsx
+++ b/vite-project/src/pages/ElevationPageV2.tsx
@@ -35,10 +35,11 @@ export default function ElevationPage() {
     DEFAULT_ANALYSIS_SETTINGS
   );
 
-  // Current document ID (synced with URL)
-  const [currentDocId, setCurrentDocId] = useState<string | null>(
-    urlDocId || null
-  );
+  // Fresh-upload identity. uploadDocId is the real Firestore id (used for
+  // mutations/poster); uploadSlugPath is the pretty "{slug}-{shortId}" segment
+  // (used for the share URL).
+  const [uploadDocId, setUploadDocId] = useState<string | null>(null);
+  const [uploadSlugPath, setUploadSlugPath] = useState<string | null>(null);
 
   // Initialize hooks
   const { performAnalysis, getCachedAnalysis, handleSettingsChange } =
@@ -51,6 +52,7 @@ export default function ElevationPage() {
     originalGpxText: sharedOriginalGpxText,
     loading: routeLoading,
     error: routeError,
+    resolvedDocId,
     setRouteMetadata,
     setAnalysisData: setSharedAnalysisData,
     setOriginalGpxText: setSharedOriginalGpxText,
@@ -66,15 +68,30 @@ export default function ElevationPage() {
     analysisSettings,
     performAnalysis,
     onSuccess: (_analysisData, fileData) => {
-      // Update current doc ID after successful upload
-      if (fileData.docId) {
-        setCurrentDocId(fileData.docId);
+      // Capture both the real doc id and the pretty share path after upload.
+      if (fileData.docId) setUploadDocId(fileData.docId);
+      if (fileData.displayUrl) {
+        setUploadSlugPath(
+          fileData.displayUrl.replace(/^\/elevation(finder|-finder)\//, "")
+        );
       }
     },
   });
 
   // Determine which data source to use (shared route vs fresh upload)
   const isSharedRoute = !!urlDocId;
+
+  // Real Firestore doc id for mutations (filename edit, poster, ownership).
+  // For shared routes this is the resolved id (the URL may be a pretty slug);
+  // for fresh uploads it's the id returned by the uploader.
+  const realDocId = isSharedRoute ? resolvedDocId : uploadDocId;
+
+  // Pretty path segment for the share URL: the URL param itself when viewing a
+  // shared route, or the slug path captured from a fresh upload.
+  const sharePath = isSharedRoute ? urlDocId ?? null : uploadSlugPath;
+
+  // Whether a route is currently loaded (controls uploader vs action buttons).
+  const hasRoute = isSharedRoute || !!uploadDocId;
   const analysisData = isSharedRoute
     ? sharedAnalysisData
     : uploadState.analysisData;
@@ -108,14 +125,6 @@ export default function ElevationPage() {
     }
   }, [urlDocId, navigate, location.search]);
 
-  // Sync currentDocId with URL changes
-  useEffect(() => {
-    console.log(
-      `🔄 URL changed: urlDocId="${urlDocId}", updating currentDocId`
-    );
-    setCurrentDocId(urlDocId || null);
-  }, [urlDocId]);
-
   // Handle settings change
   const onSettingsChange = async (newSettings: AnalysisSettings) => {
     console.log(`🔧 Settings change requested`);
@@ -125,7 +134,7 @@ export default function ElevationPage() {
       await handleSettingsChange(
         newSettings,
         analysisSettings,
-        currentDocId,
+        realDocId,
         routeMetadata,
         originalGpxText,
         filename
@@ -145,7 +154,8 @@ export default function ElevationPage() {
 
   // Handle upload new route
   const handleUploadNew = () => {
-    setCurrentDocId(null);
+    setUploadDocId(null);
+    setUploadSlugPath(null);
     resetUploadState();
     setRouteMetadata(null);
     setSharedAnalysisData(null);
@@ -248,17 +258,17 @@ export default function ElevationPage() {
         </h1>
 
         {/* Upload Section (only show if no current route) */}
-        {!currentDocId && <GpxUploader onFileParsed={handleFileParsed} />}
+        {!hasRoute && <GpxUploader onFileParsed={handleFileParsed} />}
 
         {/* Action Buttons (show when we have a route) */}
-        {currentDocId && (
+        {hasRoute && (
           <div className="text-center space-y-3">
             <div className="flex justify-center gap-2 sm:gap-3 flex-wrap">
               <Button variant="outline" onClick={handleUploadNew}>
                 📁 Upload New Route
               </Button>
 
-              <ShareButton docId={currentDocId} />
+              <ShareButton path={sharePath ?? undefined} />
 
               <PosterButton
                 displayPoints={
@@ -343,7 +353,7 @@ export default function ElevationPage() {
               "Your Route"
             }
             filename={filename}
-            docId={currentDocId}
+            docId={realDocId}
             isOwner={
               auth.user && routeMetadata
                 ? routeMetadata.userId === auth.user.uid


### PR DESCRIPTION
## Summary

Uploaded GPX routes now get pretty, shareable URLs that match the blog/race slug style, instead of an opaque Firebase doc id:

```
Before:  /elevationfinder/8Cf8rFpXCSSBuHg540wR
After:   /elevationfinder/boston-marathon-a3f9c
```

The slug is **owner-editable from the dashboard**; the trailing short id is the real resolution key, so renaming never breaks an existing link.

## How it works

- **`src/lib/routeSlug.ts`** (new) — `slugify`, `generateShortId` (6-char base36), `buildRouteSlugPath`, `buildRouteUrl`, `extractShortId`.
- **On upload**, each route stores an editable `slug` (derived from the filename) plus an immutable `shortId`. The address bar and Share dialog use the pretty path.
- **Resolution** (`useRouteLoader`): pretty `{slug}-{shortId}` URLs resolve on the trailing `shortId` via a Firestore query; the slug is cosmetic. URLs with no hyphen fall back to a direct doc lookup.
- **Backward compatible**: Firestore auto-ids are hyphen-free 20-char strings, which cleanly distinguishes legacy `/elevationfinder/{docId}` links — they route to the direct-lookup fallback and keep working.
- **Dashboard editing**: each uploaded route card gains an **Edit URL** button → modal with a live URL preview. The `shortId` is preserved (and minted for legacy routes on first edit), so shared links never break on rename.

## Notes

- No Firestore rules or index changes needed — `gpx_uploads` already allows public read (covers the `shortId` query), and single-field equality queries use the automatic index.
- Existing uploads keep working on their old doc-id URLs and gain a pretty URL the first time their owner edits the slug.

## Verification

- `tsc -b` clean
- Full `npm run build` clean (exit 0, all 80+ prerender routes generated)
- Lint shows only pre-existing `console`/exhaustive-deps warnings
- Slug helpers pass a runtime check (accents, junk input, length cap, legacy-id discrimination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013vrVKTbMjPPoeDcpzsPrR5)_