### PR TITLE
Rebuild blog with WordPress-style UX and richer related articles

### DIFF
--- a/vite-project/prerender.jsx
+++ b/vite-project/prerender.jsx
@@ -7,6 +7,121 @@ import {
   fuelSeoPages,
   raceSeoPages,
 } from "./src/features/seo-pages/seoPages";
+import blogData from "./src/data/blog-posts.json";
+import { stripLeadingH1 } from "./src/features/blog/utils";
+
+// Blog posts keyed by their public URL, for prerendered SEO content.
+const blogPostsByUrl = Object.fromEntries(
+  blogData.posts.map((p) => [`/blog/${p.slug}`, p])
+);
+
+const BLOG_LIST_TITLE =
+  "Running Blog - Training Tips, Race Strategy & Nutrition | TrainPace";
+const BLOG_LIST_DESCRIPTION =
+  "Expert running advice for marathoners and distance runners. Training tips, race strategy guides, nutrition planning, and more from TrainPace.";
+
+// Strip inline markdown (bold/italic/code/links) down to readable text. The static
+// HTML only needs crawlable prose — the live app renders the rich version.
+function stripInlineMarkdown(text) {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images -> alt
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links -> text
+    .replace(/`([^`]+)`/g, "$1") // inline code
+    .replace(/(\*\*|__)(.*?)\1/g, "$2") // bold
+    .replace(/(\*|_)(.*?)\1/g, "$2") // italic
+    .trim();
+}
+
+// Convert a markdown string into a flat list of React block elements. Handles the
+// subset used by the blog: headings, lists, blockquotes, tables, and paragraphs.
+function markdownToReactBlocks(markdown) {
+  const lines = markdown.split("\n");
+  const blocks = [];
+  let key = 0;
+  let paragraph = [];
+  let list = null; // { ordered, items: [] }
+
+  const flushParagraph = () => {
+    if (paragraph.length) {
+      blocks.push(
+        React.createElement("p", { key: key++ }, stripInlineMarkdown(paragraph.join(" ")))
+      );
+      paragraph = [];
+    }
+  };
+  const flushList = () => {
+    if (list) {
+      blocks.push(
+        React.createElement(
+          list.ordered ? "ol" : "ul",
+          { key: key++ },
+          list.items.map((it, i) =>
+            React.createElement("li", { key: i }, stripInlineMarkdown(it))
+          )
+        )
+      );
+      list = null;
+    }
+  };
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    const trimmed = line.trim();
+
+    if (trimmed === "") {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+    // Skip table rows / separators — not worth rendering for SEO text
+    if (/^\|.*\|$/.test(trimmed)) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+    const heading = /^(#{1,6})\s+(.*)$/.exec(trimmed);
+    if (heading) {
+      flushParagraph();
+      flushList();
+      const level = Math.min(heading[1].length, 3);
+      const tag = level <= 1 ? "h2" : `h${level}`;
+      blocks.push(
+        React.createElement(tag, { key: key++ }, stripInlineMarkdown(heading[2]))
+      );
+      continue;
+    }
+    const ordered = /^\d+\.\s+(.*)$/.exec(trimmed);
+    const unordered = /^[-*]\s+(.*)$/.exec(trimmed);
+    if (ordered || unordered) {
+      flushParagraph();
+      const item = (ordered ? ordered[1] : unordered[1]);
+      const isOrdered = !!ordered;
+      if (!list || list.ordered !== isOrdered) {
+        flushList();
+        list = { ordered: isOrdered, items: [] };
+      }
+      list.items.push(item);
+      continue;
+    }
+    if (/^>\s?/.test(trimmed)) {
+      flushParagraph();
+      flushList();
+      blocks.push(
+        React.createElement(
+          "blockquote",
+          { key: key++ },
+          stripInlineMarkdown(trimmed.replace(/^>\s?/, ""))
+        )
+      );
+      continue;
+    }
+    flushList();
+    paragraph.push(trimmed);
+  }
+  flushParagraph();
+  flushList();
+  return blocks;
+}
 
 // Marathon-specific SEO data (defined first so all functions can use it)
 const marathonSeoData = {
@@ -177,6 +292,10 @@ function getPageTitle(url) {
   const seoMeta = getSeoMeta(url);
   if (seoMeta?.title) return seoMeta.title;
 
+  if (url === "/blog") return BLOG_LIST_TITLE;
+  const blogPost = blogPostsByUrl[url];
+  if (blogPost) return `${blogPost.title} | TrainPace Blog`;
+
   switch (url) {
     case "/":
       return "TrainPace – Free Running Pace Calculator & Race Day Tools";
@@ -206,6 +325,10 @@ function getPageDescription(url) {
   const seoMeta = getSeoMeta(url);
   if (seoMeta?.description) return seoMeta.description;
 
+  if (url === "/blog") return BLOG_LIST_DESCRIPTION;
+  const blogPost = blogPostsByUrl[url];
+  if (blogPost) return blogPost.excerpt;
+
   switch (url) {
     case "/":
       return "Free running calculator for training paces, race fueling, and GPX elevation analysis. Get VDOT-based pace zones, plan how many gels to carry, and preview marathon course profiles.";
@@ -233,6 +356,46 @@ function getPageDescription(url) {
 
 // Helper function to get page content for prerendering
 function getPageContent(url) {
+  // Blog list: heading + description + a crawlable list of every post.
+  if (url === "/blog") {
+    return React.createElement(
+      "div",
+      null,
+      React.createElement("h1", null, "Run Smarter, Race Better"),
+      React.createElement("p", null, BLOG_LIST_DESCRIPTION),
+      React.createElement(
+        "ul",
+        null,
+        blogData.posts.map((p) =>
+          React.createElement(
+            "li",
+            { key: p.slug },
+            React.createElement("a", { href: `/blog/${p.slug}` }, p.title),
+            " — ",
+            p.excerpt
+          )
+        )
+      )
+    );
+  }
+
+  // Blog post: full article body (leading H1 stripped — the header owns the H1).
+  const blogPost = blogPostsByUrl[url];
+  if (blogPost) {
+    return React.createElement(
+      "article",
+      null,
+      React.createElement("h1", null, blogPost.title),
+      React.createElement("p", null, blogPost.excerpt),
+      React.createElement(
+        "p",
+        null,
+        `By ${blogPost.author?.name || "TrainPace"} · ${blogPost.readingTime} min read`
+      ),
+      ...markdownToReactBlocks(stripLeadingH1(blogPost.content))
+    );
+  }
+
   const seoMeta = getSeoMeta(url);
   if (seoMeta) {
     return React.createElement(
@@ -352,6 +515,83 @@ function getPageContent(url) {
 
 // Helper function to get structured data
 function getStructuredData(url) {
+  if (url === "/blog") {
+    return {
+      "@context": "https://schema.org",
+      "@type": "Blog",
+      name: "TrainPace Blog",
+      description: BLOG_LIST_DESCRIPTION,
+      url: "https://trainpace.com/blog",
+      publisher: {
+        "@type": "Organization",
+        name: "TrainPace",
+        url: "https://trainpace.com",
+      },
+      blogPost: blogData.posts.slice(0, 10).map((p) => ({
+        "@type": "BlogPosting",
+        headline: p.title,
+        description: p.excerpt,
+        datePublished: p.date,
+        url: `https://trainpace.com/blog/${p.slug}`,
+        author: { "@type": "Person", name: p.author?.name || "TrainPace" },
+      })),
+    };
+  }
+
+  const blogPost = blogPostsByUrl[url];
+  if (blogPost) {
+    return {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "BlogPosting",
+          headline: blogPost.title,
+          description: blogPost.excerpt,
+          ...(blogPost.coverImage ? { image: blogPost.coverImage } : {}),
+          datePublished: blogPost.date,
+          dateModified: blogPost.date,
+          author: {
+            "@type": "Person",
+            name: blogPost.author?.name || "TrainPace",
+          },
+          publisher: {
+            "@type": "Organization",
+            name: "TrainPace",
+            url: "https://trainpace.com",
+          },
+          mainEntityOfPage: {
+            "@type": "WebPage",
+            "@id": `https://trainpace.com${url}`,
+          },
+          keywords: (blogPost.tags || []).join(", "),
+        },
+        {
+          "@type": "BreadcrumbList",
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "TrainPace",
+              item: "https://trainpace.com/",
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Blog",
+              item: "https://trainpace.com/blog",
+            },
+            {
+              "@type": "ListItem",
+              position: 3,
+              name: blogPost.title,
+              item: `https://trainpace.com${url}`,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
   const seoMeta = getSeoMeta(url);
   if (seoMeta) {
     const breadcrumb = getBreadcrumbForUrl(url, seoMeta.title);
@@ -415,6 +655,14 @@ export async function prerender(data) {
       React.createElement("div", null, getPageContent(data.url))
     );
 
+    // Blog posts are articles, not the site app — reflect that in OG tags.
+    const blogPost = blogPostsByUrl[data.url];
+    const ogType = blogPost ? "article" : "website";
+    const ogImage =
+      blogPost && blogPost.coverImage
+        ? `https://trainpace.com${blogPost.coverImage}`
+        : "https://trainpace.com/landing-page-2025.png";
+
     return {
       html,
       head: {
@@ -453,7 +701,7 @@ export async function prerender(data) {
             type: "meta",
             props: {
               property: "og:image",
-              content: "https://trainpace.com/landing-page-2025.png",
+              content: ogImage,
             },
           },
           {
@@ -467,7 +715,7 @@ export async function prerender(data) {
             type: "meta",
             props: {
               property: "og:type",
-              content: "website",
+              content: ogType,
             },
           },
           // Twitter Card tags
@@ -496,7 +744,7 @@ export async function prerender(data) {
             type: "meta",
             props: {
               name: "twitter:image",
-              content: "https://trainpace.com/landing-page-2025.png",
+              content: ogImage,
             },
           },
           // Canonical URL

--- a/vite-project/prerender.jsx
+++ b/vite-project/prerender.jsx
@@ -23,12 +23,16 @@ const BLOG_LIST_DESCRIPTION =
 // Strip inline markdown (bold/italic/code/links) down to readable text. The static
 // HTML only needs crawlable prose — the live app renders the rich version.
 function stripInlineMarkdown(text) {
+  // All patterns use negated character classes (no nested/backref quantifiers)
+  // so they run in linear time — no catastrophic backtracking on odd input.
   return text
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images -> alt
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links -> text
     .replace(/`([^`]+)`/g, "$1") // inline code
-    .replace(/(\*\*|__)(.*?)\1/g, "$2") // bold
-    .replace(/(\*|_)(.*?)\1/g, "$2") // italic
+    .replace(/\*\*([^*]+)\*\*/g, "$1") // bold **
+    .replace(/__([^_]+)__/g, "$1") // bold __
+    .replace(/\*([^*]+)\*/g, "$1") // italic *
+    .replace(/_([^_]+)_/g, "$1") // italic _
     .trim();
 }
 

--- a/vite-project/src/features/blog/components/BlogCard.tsx
+++ b/vite-project/src/features/blog/components/BlogCard.tsx
@@ -1,42 +1,214 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { Clock, Calendar } from "lucide-react";
+import {
+  Clock,
+  Calendar,
+  ArrowRight,
+  TrendingUp,
+  Apple,
+  Flag,
+  Footprints,
+  HeartPulse,
+  Rocket,
+  Zap,
+  BookOpen,
+  type LucideIcon,
+} from "lucide-react";
 import { BlogPost, categoryLabels, categoryColors } from "../types";
 import { formatDate } from "../utils";
 
+type BlogCardVariant = "default" | "featured" | "horizontal" | "compact";
+
 interface BlogCardProps {
   post: BlogPost;
+  /** @deprecated use variant="featured" */
   featured?: boolean;
+  variant?: BlogCardVariant;
 }
 
-export default function BlogCard({ post, featured = false }: BlogCardProps) {
+// Deterministic gradient + icon per category, so image-less posts get a distinct
+// cover WITHOUT repeating the title (which already appears as the card heading).
+const categoryGradients: Record<string, string> = {
+  training: "from-blue-500 to-indigo-600",
+  nutrition: "from-emerald-500 to-green-600",
+  "race-strategy": "from-purple-500 to-fuchsia-600",
+  gear: "from-orange-500 to-amber-600",
+  recovery: "from-teal-500 to-cyan-600",
+  beginner: "from-yellow-500 to-amber-500",
+  advanced: "from-rose-500 to-red-600",
+};
+
+const categoryIcons: Record<string, LucideIcon> = {
+  training: TrendingUp,
+  nutrition: Apple,
+  "race-strategy": Flag,
+  gear: Footprints,
+  recovery: HeartPulse,
+  beginner: Rocket,
+  advanced: Zap,
+};
+
+function CoverFallback({
+  post,
+  showLabel = true,
+  className = "",
+}: {
+  post: BlogPost;
+  showLabel?: boolean;
+  className?: string;
+}) {
+  const gradient =
+    categoryGradients[post.category] || "from-emerald-500 to-emerald-700";
+  const Icon = categoryIcons[post.category] || BookOpen;
+  return (
+    <div
+      aria-hidden="true"
+      className={`overflow-hidden bg-gradient-to-br ${gradient} flex flex-col items-center justify-center gap-2 p-4 text-white ${className}`}
+    >
+      <Icon className="w-1/4 h-1/4 min-w-6 min-h-6 max-w-12 max-h-12 opacity-90 group-hover:scale-110 transition-transform duration-500" />
+      {showLabel && (
+        <span className="text-xs font-semibold uppercase tracking-wide text-white/90">
+          {categoryLabels[post.category]}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function CoverVisual({
+  post,
+  showLabel = true,
+  className = "",
+}: {
+  post: BlogPost;
+  showLabel?: boolean;
+  className?: string;
+}) {
+  const [errored, setErrored] = useState(false);
+
+  if (post.coverImage && !errored) {
+    return (
+      <div className={`overflow-hidden bg-gray-100 ${className}`}>
+        <img
+          src={post.coverImage}
+          alt={post.title}
+          loading="lazy"
+          onError={() => setErrored(true)}
+          // Guard against a "200 but not an image" response (e.g. SPA fallback):
+          // a decoded image with zero natural size means the file is missing.
+          onLoad={(e) => {
+            if (e.currentTarget.naturalWidth === 0) setErrored(true);
+          }}
+          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+        />
+      </div>
+    );
+  }
+  return (
+    <CoverFallback post={post} showLabel={showLabel} className={className} />
+  );
+}
+
+export default function BlogCard({
+  post,
+  featured = false,
+  variant,
+}: BlogCardProps) {
+  const resolved: BlogCardVariant = variant ?? (featured ? "featured" : "default");
+
+  // Compact: text-only row for sidebars and "more like this" lists.
+  if (resolved === "compact") {
+    return (
+      <Link
+        to={`/blog/${post.slug}`}
+        className="group flex gap-3 items-start py-2"
+      >
+        <CoverVisual
+          post={post}
+          showLabel={false}
+          className="w-16 h-16 rounded-lg shrink-0"
+        />
+        <div className="min-w-0">
+          <h4 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2 group-hover:text-emerald-600 transition-colors">
+            {post.title}
+          </h4>
+          <div className="flex items-center gap-2 mt-1 text-xs text-gray-500">
+            <Calendar className="w-3 h-3" />
+            <span>{formatDate(post.date)}</span>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
+  // Horizontal: image left, content right — good for dense list rows.
+  if (resolved === "horizontal") {
+    return (
+      <article className="group flex flex-col sm:flex-row gap-4 sm:gap-6 bg-white rounded-xl border border-gray-200 overflow-hidden hover:border-emerald-300 hover:shadow-md transition-all duration-300">
+        <Link
+          to={`/blog/${post.slug}`}
+          className="sm:w-56 shrink-0"
+          aria-label={post.title}
+        >
+          <CoverVisual post={post} className="aspect-video sm:h-full" />
+        </Link>
+        <div className="flex flex-col justify-center p-5 sm:pl-0 sm:pr-6 min-w-0">
+          <div className="mb-2">
+            <span
+              className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${categoryColors[post.category]}`}
+            >
+              {categoryLabels[post.category]}
+            </span>
+          </div>
+          <Link to={`/blog/${post.slug}`}>
+            <h3 className="text-lg font-bold text-gray-900 leading-snug mb-1.5 line-clamp-2 group-hover:text-emerald-600 transition-colors">
+              {post.title}
+            </h3>
+          </Link>
+          <p className="text-sm text-gray-600 line-clamp-2 mb-3">
+            {post.excerpt}
+          </p>
+          <div className="flex items-center gap-4 text-xs text-gray-500">
+            <span className="flex items-center gap-1">
+              <Calendar className="w-3.5 h-3.5" />
+              {formatDate(post.date)}
+            </span>
+            <span className="flex items-center gap-1">
+              <Clock className="w-3.5 h-3.5" />
+              {post.readingTime} min read
+            </span>
+          </div>
+        </div>
+      </article>
+    );
+  }
+
+  const isFeatured = resolved === "featured";
+
+  // Default / featured vertical card.
   return (
     <article
       className={`
-        group bg-white rounded-xl border border-gray-200 overflow-hidden
+        group bg-white rounded-xl border border-gray-200 overflow-hidden flex flex-col
         hover:border-emerald-300 hover:shadow-lg transition-all duration-300
-        ${featured ? "md:col-span-2 md:grid md:grid-cols-2" : ""}
+        ${isFeatured ? "md:col-span-2 md:grid md:grid-cols-2 md:items-stretch" : ""}
       `}
     >
-      {/* Image placeholder - can be enabled if coverImage is provided */}
-      {post.coverImage && (
-        <div className="aspect-video bg-gradient-to-br from-emerald-100 to-emerald-100 overflow-hidden">
-          <img
-            src={post.coverImage}
-            alt={post.title}
-            className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-          />
-        </div>
-      )}
+      <Link
+        to={`/blog/${post.slug}`}
+        aria-label={post.title}
+        className={isFeatured ? "md:h-full" : ""}
+      >
+        <CoverVisual
+          post={post}
+          className={isFeatured ? "aspect-video md:h-full md:aspect-auto" : "aspect-video"}
+        />
+      </Link>
 
-      {/* Content */}
-      <div className={`p-6 ${featured ? "flex flex-col justify-center" : ""}`}>
-        {/* Category badge */}
+      <div className={`p-6 flex flex-col ${isFeatured ? "justify-center" : "flex-1"}`}>
         <div className="flex items-center gap-2 mb-3">
           <span
-            className={`
-              px-3 py-1 rounded-full text-xs font-medium
-              ${categoryColors[post.category]}
-            `}
+            className={`px-3 py-1 rounded-full text-xs font-medium ${categoryColors[post.category]}`}
           >
             {categoryLabels[post.category]}
           </span>
@@ -47,30 +219,24 @@ export default function BlogCard({ post, featured = false }: BlogCardProps) {
           )}
         </div>
 
-        {/* Title */}
         <Link to={`/blog/${post.slug}`}>
           <h3
             className={`
               font-bold text-gray-900 group-hover:text-emerald-600 transition-colors
-              ${featured ? "text-2xl md:text-3xl mb-3" : "text-xl mb-2"}
+              ${isFeatured ? "text-2xl md:text-3xl mb-3" : "text-xl mb-2"}
             `}
           >
             {post.title}
           </h3>
         </Link>
 
-        {/* Excerpt */}
         <p
-          className={`
-            text-gray-600 mb-4 line-clamp-2
-            ${featured ? "text-base" : "text-sm"}
-          `}
+          className={`text-gray-600 mb-4 line-clamp-2 ${isFeatured ? "text-base" : "text-sm"}`}
         >
           {post.excerpt}
         </p>
 
-        {/* Meta info */}
-        <div className="flex items-center gap-4 text-sm text-gray-500">
+        <div className="flex items-center gap-4 text-sm text-gray-500 mt-auto">
           <div className="flex items-center gap-1">
             <Calendar className="w-4 h-4" />
             <span>{formatDate(post.date)}</span>
@@ -81,25 +247,12 @@ export default function BlogCard({ post, featured = false }: BlogCardProps) {
           </div>
         </div>
 
-        {/* Read more link */}
         <Link
           to={`/blog/${post.slug}`}
           className="inline-flex items-center mt-4 text-emerald-600 font-medium hover:text-emerald-800 transition-colors"
         >
           Read more
-          <svg
-            className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
+          <ArrowRight className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
         </Link>
       </div>
     </article>

--- a/vite-project/src/features/blog/components/BlogList.tsx
+++ b/vite-project/src/features/blog/components/BlogList.tsx
@@ -1,49 +1,99 @@
-import { useState } from "react";
+import { useState, useMemo, useEffect } from "react";
+import { useSearchParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
-import { Search, Tag, Filter } from "lucide-react";
+import { Search, X, BookOpen } from "lucide-react";
 import BlogCard from "./BlogCard";
+import BlogSidebar from "./BlogSidebar";
 import { BlogCategory, categoryLabels, categoryColors } from "../types";
-import {
-  getAllPosts,
-  getFeaturedPosts,
-  getActiveCategories,
-  getAllTags,
-} from "../utils";
+import { getAllPosts, getFeaturedPosts, getActiveCategories } from "../utils";
 import { Button } from "@/components/ui/button";
 
+const PAGE_SIZE = 9;
+
 export default function BlogList() {
-  const [selectedCategory, setSelectedCategory] = useState<
-    BlogCategory | "all"
-  >("all");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [showFilters, setShowFilters] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const allPosts = getAllPosts();
-  const featuredPosts = getFeaturedPosts();
-  const categories = getActiveCategories();
-  const tags = getAllTags();
+  const categoryParam = searchParams.get("category") as BlogCategory | null;
+  const searchParam = searchParams.get("search") || "";
 
-  // Filter posts
-  const filteredPosts = allPosts.filter((post) => {
-    // Category filter
-    if (selectedCategory !== "all" && post.category !== selectedCategory) {
-      return false;
-    }
+  const selectedCategory: BlogCategory | "all" = categoryParam || "all";
+  const [searchInput, setSearchInput] = useState(searchParam);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
-    // Search filter
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      return (
-        post.title.toLowerCase().includes(query) ||
-        post.excerpt.toLowerCase().includes(query) ||
-        post.tags.some((tag) => tag.toLowerCase().includes(query))
-      );
-    }
+  const trimmedSearch = searchInput.trim();
 
-    return true;
-  });
+  // Keep the input in sync when the URL changes externally (e.g. sidebar tag links).
+  useEffect(() => {
+    if (searchParam !== searchInput) setSearchInput(searchParam);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParam]);
 
-  // Schema for blog listing
+  // Debounce writing the (live) search term back to the URL so it stays shareable
+  // without a page reload per keystroke.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      if (trimmedSearch !== searchParam) {
+        const params = new URLSearchParams(searchParams);
+        if (trimmedSearch) params.set("search", trimmedSearch);
+        else params.delete("search");
+        setSearchParams(params, { replace: true });
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trimmedSearch]);
+
+  // Reset pagination whenever the filters change.
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [selectedCategory, trimmedSearch]);
+
+  const allPosts = useMemo(() => getAllPosts(), []);
+  const featuredPosts = useMemo(() => getFeaturedPosts(), []);
+  const categories = useMemo(() => getActiveCategories(), []);
+
+  const isFiltering = selectedCategory !== "all" || !!trimmedSearch;
+
+  const filteredPosts = useMemo(() => {
+    const query = trimmedSearch.toLowerCase();
+    return allPosts.filter((post) => {
+      if (selectedCategory !== "all" && post.category !== selectedCategory) {
+        return false;
+      }
+      if (query) {
+        return (
+          post.title.toLowerCase().includes(query) ||
+          post.excerpt.toLowerCase().includes(query) ||
+          post.tags.some((tag) => tag.toLowerCase().includes(query))
+        );
+      }
+      return true;
+    });
+  }, [allPosts, selectedCategory, trimmedSearch]);
+
+  const heroPost = featuredPosts[0] || allPosts[0];
+  // On the default view the hero is shown separately, so drop it from the grid.
+  const gridPosts = useMemo(() => {
+    if (isFiltering) return filteredPosts;
+    return filteredPosts.filter((post) => post.slug !== heroPost?.slug);
+  }, [filteredPosts, isFiltering, heroPost]);
+
+  const visiblePosts = gridPosts.slice(0, visibleCount);
+
+  const setCategory = (category: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (category && category !== "all") params.set("category", category);
+    else params.delete("category");
+    setSearchParams(params, { replace: true });
+  };
+
+  const clearSearch = () => setSearchInput("");
+
+  const clearAllFilters = () => {
+    setSearchInput("");
+    setSearchParams({}, { replace: true });
+  };
+
   const blogSchema = {
     "@context": "https://schema.org",
     "@type": "Blog",
@@ -62,15 +112,12 @@ export default function BlogList() {
       description: post.excerpt,
       datePublished: post.date,
       url: `https://trainpace.com/blog/${post.slug}`,
-      author: {
-        "@type": "Person",
-        name: post.author.name,
-      },
+      author: { "@type": "Person", name: post.author.name },
     })),
   };
 
   return (
-    <div className="bg-white text-gray-900 min-h-screen">
+    <div className="bg-gray-50 text-gray-900 min-h-screen">
       <Helmet>
         <title>
           Running Blog - Training Tips, Race Strategy & Nutrition | TrainPace
@@ -83,180 +130,158 @@ export default function BlogList() {
         <script type="application/ld+json">{JSON.stringify(blogSchema)}</script>
       </Helmet>
 
-      {/* Header */}
-      <section className="py-12 px-6 text-center bg-gradient-to-br from-emerald-50 to-emerald-50">
-        <div className="max-w-3xl mx-auto">
-          <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-4">
-            TrainPace Blog
+      {/* Masthead */}
+      <section className="bg-white border-b border-gray-200">
+        <div className="max-w-6xl mx-auto px-6 py-10 text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-50 text-emerald-700 text-sm font-medium mb-4">
+            <BookOpen className="w-4 h-4" aria-hidden="true" />
+            The TrainPace Blog
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold tracking-tight mb-3">
+            Run Smarter, Race Better
           </h1>
-          <p className="text-lg text-gray-600">
-            Training tips, race strategy, and nutrition advice for runners
+          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+            Training tips, race strategy, and nutrition advice — written by
+            runners, backed by the science.
           </p>
         </div>
       </section>
 
-      {/* Search and Filters */}
-      <section className="sticky top-[71px] z-40 bg-white border-b border-gray-200 shadow-sm">
-        <div className="max-w-6xl mx-auto px-6 py-4">
-          <div className="flex flex-col md:flex-row gap-4">
-            {/* Search */}
+      {/* Sticky filter bar */}
+      <section className="sticky top-[72px] z-40 bg-white/95 backdrop-blur border-b border-gray-200 shadow-sm">
+        <div className="max-w-6xl mx-auto px-6 py-3">
+          <div className="flex flex-col lg:flex-row lg:items-center gap-3">
             <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Search
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400"
+                aria-hidden="true"
+              />
               <input
                 type="text"
+                aria-label="Search articles"
                 placeholder="Search articles..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                className="w-full pl-10 pr-10 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 outline-none"
               />
+              {searchInput && (
+                <button
+                  type="button"
+                  onClick={clearSearch}
+                  aria-label="Clear search"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
             </div>
 
-            {/* Filter toggle (mobile) */}
-            <Button
-              onClick={() => setShowFilters(!showFilters)}
-              variant="outline"
-              className="md:hidden flex items-center justify-center gap-2"
-            >
-              <Filter className="w-5 h-5" />
-              <span>Filters</span>
-            </Button>
-
-            {/* Category filters (desktop) */}
-            <div className="hidden md:flex items-center gap-2">
-              <Button
-                onClick={() => setSelectedCategory("all")}
-                variant={selectedCategory === "all" ? "default" : "secondary"}
-                className="rounded-full"
+            <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:pb-0 -mx-6 px-6 lg:mx-0 lg:px-0">
+              <button
+                onClick={() => setCategory("all")}
+                className={`shrink-0 px-4 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+                  selectedCategory === "all"
+                    ? "bg-gray-900 text-white border-gray-900"
+                    : "bg-white text-gray-600 border-gray-200 hover:border-gray-300"
+                }`}
               >
                 All
-              </Button>
+              </button>
               {categories.map((category) => (
-                <Button
+                <button
                   key={category}
-                  onClick={() => setSelectedCategory(category)}
-                  variant={
-                    selectedCategory === category ? "default" : "secondary"
-                  }
-                  className={`rounded-full ${
+                  onClick={() => setCategory(category)}
+                  className={`shrink-0 px-4 py-1.5 rounded-full text-sm font-medium border transition-colors ${
                     selectedCategory === category
-                      ? categoryColors[category]
-                      : ""
+                      ? `${categoryColors[category]} border-transparent`
+                      : "bg-white text-gray-600 border-gray-200 hover:border-gray-300"
                   }`}
                 >
                   {categoryLabels[category]}
-                </Button>
+                </button>
               ))}
             </div>
           </div>
-
-          {/* Mobile filters dropdown */}
-          {showFilters && (
-            <div className="md:hidden mt-4 pt-4 border-t border-gray-200">
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  onClick={() => {
-                    setSelectedCategory("all");
-                    setShowFilters(false);
-                  }}
-                  variant={selectedCategory === "all" ? "default" : "secondary"}
-                  className="rounded-full"
-                >
-                  All
-                </Button>
-                {categories.map((category) => (
-                  <Button
-                    key={category}
-                    onClick={() => {
-                      setSelectedCategory(category);
-                      setShowFilters(false);
-                    }}
-                    variant={
-                      selectedCategory === category ? "default" : "secondary"
-                    }
-                    className={`rounded-full ${
-                      selectedCategory === category
-                        ? categoryColors[category]
-                        : ""
-                    }`}
-                  >
-                    {categoryLabels[category]}
-                  </Button>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
       </section>
 
-      {/* Featured Posts */}
-      {selectedCategory === "all" &&
-        !searchQuery &&
-        featuredPosts.length > 0 && (
-          <section className="py-12 px-6 bg-gray-50">
-            <div className="max-w-6xl mx-auto">
-              <h2 className="text-2xl font-bold mb-6 flex items-center gap-2">
-                <span className="text-yellow-500">★</span>
-                Featured Articles
-              </h2>
-              <div className="grid md:grid-cols-2 gap-6">
-                {featuredPosts.slice(0, 2).map((post) => (
-                  <BlogCard key={post.slug} post={post} featured />
-                ))}
-              </div>
-            </div>
-          </section>
-        )}
-
-      {/* All Posts */}
-      <section className="py-12 px-6">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-2xl font-bold mb-6">
-            {selectedCategory === "all"
-              ? "All Articles"
-              : `${categoryLabels[selectedCategory]} Articles`}
-            {searchQuery && ` matching "${searchQuery}"`}
-          </h2>
-
-          {filteredPosts.length > 0 ? (
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filteredPosts.map((post) => (
-                <BlogCard key={post.slug} post={post} />
-              ))}
-            </div>
-          ) : (
-            <div className="text-center py-12 text-gray-500">
-              <p className="text-lg">No articles found.</p>
-              <p className="mt-2">Try adjusting your search or filters.</p>
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Tags Section */}
-      {selectedCategory === "all" && !searchQuery && (
-        <section className="py-12 px-6 bg-gray-50">
-          <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold mb-6 flex items-center gap-2">
-              <Tag className="w-6 h-6" />
-              Browse by Topic
-            </h2>
-            <div className="flex flex-wrap gap-2">
-              {tags.map((tag) => (
-                <Button
-                  key={tag}
-                  onClick={() => setSearchQuery(tag)}
-                  className="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-700 hover:border-emerald-300 hover:text-emerald-600 transition-all"
-                >
-                  {tag}
-                </Button>
-              ))}
-            </div>
-          </div>
+      {/* Hero featured post (default view only) */}
+      {!isFiltering && heroPost && (
+        <section className="max-w-6xl mx-auto px-6 pt-10">
+          <BlogCard post={heroPost} variant="featured" />
         </section>
       )}
 
-      {/* CTA Section */}
-      <section className="py-16 text-center bg-gradient-to-r from-emerald-600 to-emerald-600 text-white">
+      {/* Main content + sidebar */}
+      <section className="max-w-6xl mx-auto px-6 py-10">
+        <div className="grid md:grid-cols-[1fr_260px] lg:grid-cols-[1fr_320px] gap-8 lg:gap-10">
+          <main>
+            <div className="flex items-baseline justify-between mb-6 gap-4">
+              <h2 className="text-2xl font-bold">
+                {trimmedSearch
+                  ? `Results for "${trimmedSearch}"`
+                  : selectedCategory === "all"
+                    ? "Latest Articles"
+                    : `${categoryLabels[selectedCategory]} Articles`}
+              </h2>
+              {isFiltering && (
+                <button
+                  onClick={clearAllFilters}
+                  className="text-sm text-emerald-600 hover:text-emerald-800 whitespace-nowrap"
+                >
+                  Clear filters
+                </button>
+              )}
+            </div>
+
+            {visiblePosts.length > 0 ? (
+              <>
+                <div className="grid sm:grid-cols-2 gap-6">
+                  {visiblePosts.map((post) => (
+                    <BlogCard key={post.slug} post={post} />
+                  ))}
+                </div>
+
+                {visibleCount < gridPosts.length && (
+                  <div className="text-center mt-10">
+                    <Button
+                      variant="outline"
+                      onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+                      className="px-8"
+                    >
+                      Load more articles
+                    </Button>
+                    <p className="text-sm text-gray-500 mt-3">
+                      Showing {visiblePosts.length} of {gridPosts.length}
+                    </p>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="text-center py-16 bg-white rounded-xl border border-gray-200">
+                <p className="text-lg font-medium text-gray-700">
+                  No articles found.
+                </p>
+                <p className="mt-2 text-gray-500">
+                  Try a different search or category.
+                </p>
+                <Button onClick={clearAllFilters} className="mt-6">
+                  View all articles
+                </Button>
+              </div>
+            )}
+          </main>
+
+          <div className="hidden md:block">
+            <div className="sticky top-[140px]">
+              <BlogSidebar activeCategory={selectedCategory} />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 text-center bg-gradient-to-r from-emerald-600 to-emerald-700 text-white">
         <div className="max-w-3xl mx-auto px-6">
           <h2 className="text-3xl font-bold mb-4">Ready to Train Smarter?</h2>
           <p className="text-emerald-100 mb-8 text-lg">
@@ -264,18 +289,18 @@ export default function BlogList() {
             analyze your race courses.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
-              href="/calculator"
+            <Link
+              to="/calculator"
               className="inline-flex items-center justify-center px-6 py-3 bg-white text-emerald-600 rounded-lg font-medium hover:bg-emerald-50 transition-colors"
             >
               Pace Calculator
-            </a>
-            <a
-              href="/fuel"
+            </Link>
+            <Link
+              to="/fuel"
               className="inline-flex items-center justify-center px-6 py-3 border-2 border-white text-white rounded-lg font-medium hover:bg-white/10 transition-colors"
             >
               Fuel Planner
-            </a>
+            </Link>
           </div>
         </div>
       </section>

--- a/vite-project/src/features/blog/components/BlogPost.tsx
+++ b/vite-project/src/features/blog/components/BlogPost.tsx
@@ -1,23 +1,204 @@
+import { useState, useEffect, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
   ArrowLeft,
+  ArrowRight,
   Clock,
   Calendar,
   Tag,
   Share2,
   ChevronRight,
+  List,
 } from "lucide-react";
 import { categoryLabels, categoryColors } from "../types";
-import { getPostBySlug, formatDate, getRelatedPosts } from "../utils";
+import {
+  getPostBySlug,
+  formatDate,
+  getRelatedPosts,
+  getMoreFromCategory,
+  getPopularPosts,
+  extractHeadings,
+  slugifyHeading,
+  stripLeadingH1,
+} from "../utils";
 import BlogCard from "./BlogCard";
 import { Button } from "@/components/ui/button";
+
+// Flatten React markdown children into a plain string for heading anchors.
+function nodeToText(children: React.ReactNode): string {
+  if (children == null) return "";
+  if (typeof children === "string" || typeof children === "number")
+    return String(children);
+  if (Array.isArray(children)) return children.map(nodeToText).join("");
+  if (
+    typeof children === "object" &&
+    "props" in (children as { props?: { children?: React.ReactNode } }) &&
+    (children as { props?: { children?: React.ReactNode } }).props
+  ) {
+    return nodeToText(
+      (children as { props: { children?: React.ReactNode } }).props.children
+    );
+  }
+  return "";
+}
+
+// Self-contained reading-progress bar. Owns its own scroll listener and state so
+// scrolling never re-renders the (expensive) article/markdown tree.
+function ReadingProgressBar() {
+  const [progress, setProgress] = useState(0);
+  useEffect(() => {
+    const onScroll = () => {
+      const el = document.getElementById("article-body");
+      if (!el) return;
+      const start = el.offsetTop;
+      const total = el.offsetHeight - window.innerHeight;
+      const scrolled = window.scrollY - start;
+      const pct = total > 0 ? (scrolled / total) * 100 : 0;
+      setProgress(Math.min(100, Math.max(0, pct)));
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    onScroll();
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, []);
+  return (
+    <div
+      className="fixed top-0 left-0 right-0 h-1 z-50 bg-transparent"
+      aria-hidden="true"
+    >
+      <div
+        className="h-full bg-emerald-500 transition-[width] duration-150 ease-out"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}
 
 export default function BlogPost() {
   const { slug } = useParams<{ slug: string }>();
   const post = getPostBySlug(slug || "");
+
+  // Scroll to top when navigating between posts.
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [slug]);
+
+  const headings = useMemo(
+    () => (post ? extractHeadings(post.content) : []),
+    [post]
+  );
+
+  const relatedPosts = useMemo(
+    () => (post ? getRelatedPosts(post.slug, 3) : []),
+    [post]
+  );
+
+  const moreFromCategory = useMemo(() => {
+    if (!post) return [];
+    const relatedSlugs = new Set(relatedPosts.map((p) => p.slug));
+    return getMoreFromCategory(post.category, post.slug, 6).filter(
+      (p) => !relatedSlugs.has(p.slug)
+    );
+  }, [post, relatedPosts]);
+
+  // Sidebar list is intentionally DIFFERENT from the bottom "Related Articles"
+  // grid so the same posts aren't shown twice on one page.
+  const sidebarPosts = useMemo(() => {
+    if (!post) return [];
+    const relatedSlugs = new Set(relatedPosts.map((p) => p.slug));
+    return getPopularPosts(8, post.slug)
+      .filter((p) => !relatedSlugs.has(p.slug))
+      .slice(0, 4);
+  }, [post, relatedPosts]);
+
+  // Render the markdown once per post — not on every scroll/interaction.
+  const renderedContent = useMemo(() => {
+    if (!post) return null;
+    const headingSeen = new Map<string, number>();
+    const makeHeadingId = (children: React.ReactNode): string => {
+      let id = slugifyHeading(nodeToText(children));
+      const count = headingSeen.get(id) || 0;
+      headingSeen.set(id, count + 1);
+      if (count > 0) id = `${id}-${count}`;
+      return id;
+    };
+    return (
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h2: ({ children }) => <h2 id={makeHeadingId(children)}>{children}</h2>,
+          h3: ({ children }) => <h3 id={makeHeadingId(children)}>{children}</h3>,
+          a: ({ href, children }) => {
+            const isInternal = href?.startsWith("/");
+            if (isInternal) {
+              return (
+                <Link
+                  to={href || "/"}
+                  className="text-emerald-600 hover:text-emerald-800"
+                >
+                  {children}
+                </Link>
+              );
+            }
+            return (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-600 hover:text-emerald-800"
+              >
+                {children}
+              </a>
+            );
+          },
+          table: ({ children }) => (
+            <div className="overflow-x-auto my-6">
+              <table className="min-w-full border border-gray-200 rounded-lg overflow-hidden">
+                {children}
+              </table>
+            </div>
+          ),
+          thead: ({ children }) => (
+            <thead className="bg-gray-50">{children}</thead>
+          ),
+          th: ({ children }) => (
+            <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900 border-b">
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td className="px-4 py-3 text-sm text-gray-700 border-b border-gray-100">
+              {children}
+            </td>
+          ),
+          code: ({ className, children }) => {
+            const isInline = !className;
+            if (isInline) {
+              return (
+                <code className="px-1.5 py-0.5 bg-gray-100 rounded text-sm text-gray-800">
+                  {children}
+                </code>
+              );
+            }
+            return <code className={className}>{children}</code>;
+          },
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-4 border-emerald-500 pl-4 italic text-gray-700 my-6">
+              {children}
+            </blockquote>
+          ),
+        }}
+      >
+        {stripLeadingH1(post.content)}
+      </ReactMarkdown>
+    );
+  }, [post]);
 
   if (!post) {
     return (
@@ -41,9 +222,6 @@ export default function BlogPost() {
     );
   }
 
-  const relatedPosts = getRelatedPosts(post.slug, 3);
-
-  // Schema for blog post
   const articleSchema = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -52,10 +230,7 @@ export default function BlogPost() {
     image: post.coverImage,
     datePublished: post.date,
     dateModified: post.date,
-    author: {
-      "@type": "Person",
-      name: post.author.name,
-    },
+    author: { "@type": "Person", name: post.author.name },
     publisher: {
       "@type": "Organization",
       name: "TrainPace",
@@ -68,23 +243,12 @@ export default function BlogPost() {
     keywords: post.tags.join(", "),
   };
 
-  // Breadcrumb schema
   const breadcrumbSchema = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      {
-        "@type": "ListItem",
-        position: 1,
-        name: "Home",
-        item: "https://trainpace.com",
-      },
-      {
-        "@type": "ListItem",
-        position: 2,
-        name: "Blog",
-        item: "https://trainpace.com/blog",
-      },
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://trainpace.com" },
+      { "@type": "ListItem", position: 2, name: "Blog", item: "https://trainpace.com/blog" },
       {
         "@type": "ListItem",
         position: 3,
@@ -98,67 +262,52 @@ export default function BlogPost() {
     const url = window.location.href;
     if (navigator.share) {
       try {
-        await navigator.share({
-          title: post.title,
-          text: post.excerpt,
-          url: url,
-        });
+        await navigator.share({ title: post.title, text: post.excerpt, url });
       } catch {
         // User cancelled or share failed
       }
     } else {
-      // Fallback: copy to clipboard
       navigator.clipboard.writeText(url);
       alert("Link copied to clipboard!");
     }
   };
 
   return (
-    <div className="bg-white text-gray-900 min-h-screen">
+    <div className="bg-gray-50 text-gray-900 min-h-screen">
       <Helmet>
         <title>{post.title} | TrainPace Blog</title>
         <meta name="description" content={post.excerpt} />
-        <link
-          rel="canonical"
-          href={`https://trainpace.com/blog/${post.slug}`}
-        />
+        <link rel="canonical" href={`https://trainpace.com/blog/${post.slug}`} />
         <meta property="og:title" content={post.title} />
         <meta property="og:description" content={post.excerpt} />
         <meta property="og:type" content="article" />
-        <meta
-          property="og:url"
-          content={`https://trainpace.com/blog/${post.slug}`}
-        />
-        {post.coverImage && (
-          <meta property="og:image" content={post.coverImage} />
-        )}
+        <meta property="og:url" content={`https://trainpace.com/blog/${post.slug}`} />
+        {post.coverImage && <meta property="og:image" content={post.coverImage} />}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={post.title} />
         <meta name="twitter:description" content={post.excerpt} />
-        <script type="application/ld+json">
-          {JSON.stringify(articleSchema)}
-        </script>
-        <script type="application/ld+json">
-          {JSON.stringify(breadcrumbSchema)}
-        </script>
+        <script type="application/ld+json">{JSON.stringify(articleSchema)}</script>
+        <script type="application/ld+json">{JSON.stringify(breadcrumbSchema)}</script>
       </Helmet>
 
+      <ReadingProgressBar />
+
       {/* Breadcrumb */}
-      <nav className="bg-gray-50 border-b border-gray-200">
-        <div className="max-w-4xl mx-auto px-6 py-3">
+      <nav className="bg-white border-b border-gray-200" aria-label="Breadcrumb">
+        <div className="max-w-6xl mx-auto px-6 py-3">
           <ol className="flex items-center gap-2 text-sm">
             <li>
               <Link to="/" className="text-gray-500 hover:text-emerald-600">
                 Home
               </Link>
             </li>
-            <ChevronRight className="w-4 h-4 text-gray-400" />
+            <ChevronRight className="w-4 h-4 text-gray-400" aria-hidden="true" />
             <li>
               <Link to="/blog" className="text-gray-500 hover:text-emerald-600">
                 Blog
               </Link>
             </li>
-            <ChevronRight className="w-4 h-4 text-gray-400" />
+            <ChevronRight className="w-4 h-4 text-gray-400" aria-hidden="true" />
             <li className="text-gray-900 font-medium truncate max-w-[200px]">
               {post.title}
             </li>
@@ -167,166 +316,179 @@ export default function BlogPost() {
       </nav>
 
       {/* Article Header */}
-      <header className="py-12 px-6 bg-gradient-to-br from-emerald-50 to-emerald-50">
-        <div className="max-w-4xl mx-auto">
-          {/* Category */}
-          <div className="mb-4">
-            <Link
-              to={`/blog?category=${post.category}`}
-              className={`
-                inline-block px-3 py-1 rounded-full text-sm font-medium
-                ${categoryColors[post.category]}
-              `}
-            >
-              {categoryLabels[post.category]}
-            </Link>
-          </div>
-
-          {/* Title */}
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight mb-6">
-            {post.title}
-          </h1>
-
-          {/* Meta */}
-          <div className="flex flex-wrap items-center gap-4 text-gray-600">
-            <div className="flex items-center gap-2">
-              <div className="w-10 h-10 rounded-full bg-emerald-600 flex items-center justify-center text-white font-bold">
-                {post.author.name.charAt(0)}
-              </div>
-              <div>
-                <div className="font-medium text-gray-900">
-                  {post.author.name}
-                </div>
-                {post.author.bio && (
-                  <div className="text-sm text-gray-500">{post.author.bio}</div>
-                )}
-              </div>
+      <header className="bg-white border-b border-gray-200">
+        <div className="max-w-6xl mx-auto px-6 py-10">
+          <div className="max-w-3xl">
+            <div className="mb-4">
+              <Link
+                to={`/blog?category=${post.category}`}
+                className={`inline-block px-3 py-1 rounded-full text-sm font-medium ${categoryColors[post.category]}`}
+              >
+                {categoryLabels[post.category]}
+              </Link>
             </div>
-            <div className="flex items-center gap-4 text-sm">
-              <span className="flex items-center gap-1">
-                <Calendar className="w-4 h-4" />
-                {formatDate(post.date)}
-              </span>
-              <span className="flex items-center gap-1">
-                <Clock className="w-4 h-4" />
-                {post.readingTime} min read
-              </span>
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold tracking-tight mb-6">
+              {post.title}
+            </h1>
+            <p className="text-lg text-gray-600 mb-6">{post.excerpt}</p>
+            <div className="flex flex-wrap items-center gap-4 text-gray-600">
+              <div className="flex items-center gap-2">
+                <div className="w-10 h-10 rounded-full bg-emerald-600 flex items-center justify-center text-white font-bold">
+                  {post.author.name.charAt(0)}
+                </div>
+                <div>
+                  <div className="font-medium text-gray-900">
+                    {post.author.name}
+                  </div>
+                  {post.author.bio && (
+                    <div className="text-sm text-gray-500 line-clamp-1">
+                      {post.author.bio}
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-4 text-sm">
+                <span className="flex items-center gap-1">
+                  <Calendar className="w-4 h-4" aria-hidden="true" />
+                  {formatDate(post.date)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <Clock className="w-4 h-4" aria-hidden="true" />
+                  {post.readingTime} min read
+                </span>
+              </div>
             </div>
           </div>
         </div>
       </header>
 
-      {/* Article Content */}
-      <article className="py-12 px-6">
-        <div className="max-w-4xl mx-auto">
-          {/* Markdown content */}
-          <div className="prose prose-lg prose-blue max-w-none text-left">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                // Custom link handling for internal links
-                a: ({ href, children }) => {
-                  const isInternal = href?.startsWith("/");
-                  if (isInternal) {
-                    return (
-                      <Link
-                        to={href || "/"}
-                        className="text-emerald-600 hover:text-emerald-800"
-                      >
-                        {children}
-                      </Link>
-                    );
-                  }
-                  return (
-                    <a
-                      href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-emerald-600 hover:text-emerald-800"
-                    >
-                      {children}
-                    </a>
-                  );
-                },
-                // Styled tables
-                table: ({ children }) => (
-                  <div className="overflow-x-auto my-6">
-                    <table className="min-w-full border border-gray-200 rounded-lg overflow-hidden">
-                      {children}
-                    </table>
-                  </div>
-                ),
-                thead: ({ children }) => (
-                  <thead className="bg-gray-50">{children}</thead>
-                ),
-                th: ({ children }) => (
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-900 border-b">
-                    {children}
-                  </th>
-                ),
-                td: ({ children }) => (
-                  <td className="px-4 py-3 text-sm text-gray-700 border-b border-gray-100">
-                    {children}
-                  </td>
-                ),
-                // Styled code blocks
-                code: ({ className, children }) => {
-                  const isInline = !className;
-                  if (isInline) {
-                    return (
-                      <code className="px-1.5 py-0.5 bg-gray-100 rounded text-sm text-gray-800">
-                        {children}
-                      </code>
-                    );
-                  }
-                  return <code className={className}>{children}</code>;
-                },
-                // Styled blockquotes
-                blockquote: ({ children }) => (
-                  <blockquote className="border-l-4 border-emerald-500 pl-4 italic text-gray-700 my-6">
-                    {children}
-                  </blockquote>
-                ),
-              }}
-            >
-              {post.content}
-            </ReactMarkdown>
-          </div>
+      {/* Body: article + sidebar */}
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <div className="grid md:grid-cols-[1fr_260px] lg:grid-cols-[1fr_300px] gap-8 lg:gap-10">
+          {/* Article */}
+          <article id="article-body">
+            {post.coverImage && (
+              <CoverImage post={post} />
+            )}
 
-          {/* Tags */}
-          <div className="mt-12 pt-8 border-t border-gray-200">
-            <div className="flex items-center gap-2 flex-wrap">
-              <Tag className="w-5 h-5 text-gray-400" />
-              {post.tags.map((tag) => (
-                <Link
-                  key={tag}
-                  to={`/blog?search=${tag}`}
-                  className="px-3 py-1 bg-gray-100 rounded-full text-sm text-gray-700 hover:bg-gray-200 transition-colors"
-                >
-                  {tag}
-                </Link>
-              ))}
+            <div className="prose prose-lg max-w-none text-left prose-headings:scroll-mt-28 prose-a:text-emerald-600 hover:prose-a:text-emerald-800">
+              {renderedContent}
             </div>
-          </div>
 
-          {/* Share */}
-          <div className="mt-8 flex items-center gap-4">
-            <span className="text-gray-600 font-medium">
-              Share this article:
-            </span>
-            <Button onClick={handleShare} variant="outline" className="gap-2">
-              <Share2 className="w-5 h-5" />
-              Share
-            </Button>
-          </div>
+            {/* Tags */}
+            <div className="mt-12 pt-8 border-t border-gray-200">
+              <div className="flex items-center gap-2 flex-wrap">
+                <Tag className="w-5 h-5 text-gray-400" aria-hidden="true" />
+                {post.tags.map((tag) => (
+                  <Link
+                    key={tag}
+                    to={`/blog?search=${encodeURIComponent(tag)}`}
+                    className="px-3 py-1 bg-white border border-gray-200 rounded-full text-sm text-gray-700 hover:border-emerald-300 hover:text-emerald-600 transition-colors"
+                  >
+                    {tag}
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            {/* Share */}
+            <div className="mt-8 flex items-center gap-4">
+              <span className="text-gray-600 font-medium">
+                Share this article:
+              </span>
+              <Button onClick={handleShare} variant="outline" className="gap-2">
+                <Share2 className="w-5 h-5" aria-hidden="true" />
+                Share
+              </Button>
+            </div>
+
+            {/* Author box */}
+            <div className="mt-10 p-6 bg-white rounded-xl border border-gray-200 flex gap-4">
+              <div className="w-14 h-14 shrink-0 rounded-full bg-emerald-600 flex items-center justify-center text-white text-xl font-bold">
+                {post.author.name.charAt(0)}
+              </div>
+              <div>
+                <div className="text-sm text-gray-500">Written by</div>
+                <div className="text-lg font-bold text-gray-900">
+                  {post.author.name}
+                </div>
+                {post.author.bio && (
+                  <p className="text-sm text-gray-600 mt-1">{post.author.bio}</p>
+                )}
+              </div>
+            </div>
+          </article>
+
+          {/* Sticky sidebar */}
+          <aside className="hidden md:block">
+            <div className="sticky top-[96px] space-y-8">
+              {headings.length >= 3 && (
+                <nav
+                  className="bg-white rounded-xl border border-gray-200 p-5"
+                  aria-label="Table of contents"
+                >
+                  <h2 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-900 mb-4">
+                    <List className="w-4 h-4 text-emerald-600" aria-hidden="true" />
+                    In this article
+                  </h2>
+                  <ul className="space-y-2 text-sm">
+                    {headings.map((h) => (
+                      <li key={h.id} className={h.level === 3 ? "pl-3" : ""}>
+                        <a
+                          href={`#${h.id}`}
+                          className="text-gray-600 hover:text-emerald-600 focus-visible:text-emerald-600 focus-visible:underline outline-none transition-colors block leading-snug"
+                        >
+                          {h.text}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+              )}
+
+              {sidebarPosts.length > 0 && (
+                <div className="bg-white rounded-xl border border-gray-200 p-5">
+                  <h2 className="text-sm font-bold uppercase tracking-wide text-gray-900 mb-4">
+                    Popular Reads
+                  </h2>
+                  <div className="divide-y divide-gray-100">
+                    {sidebarPosts.map((rp) => (
+                      <BlogCard key={rp.slug} post={rp} variant="compact" />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="rounded-xl bg-gradient-to-br from-emerald-600 to-emerald-700 p-6 text-white">
+                <h2 className="text-lg font-bold mb-2">Put it into practice</h2>
+                <p className="text-sm text-emerald-100 mb-4">
+                  Dial in your paces with the free calculator.
+                </p>
+                <Link
+                  to="/calculator"
+                  className="inline-flex items-center justify-center w-full px-4 py-2 bg-white text-emerald-700 rounded-lg text-sm font-semibold hover:bg-emerald-50 transition-colors"
+                >
+                  Open Pace Calculator
+                </Link>
+              </div>
+            </div>
+          </aside>
         </div>
-      </article>
+      </div>
 
-      {/* Related Posts */}
+      {/* Related Articles */}
       {relatedPosts.length > 0 && (
-        <section className="py-12 px-6 bg-gray-50">
+        <section className="py-12 px-6 bg-white border-t border-gray-200">
           <div className="max-w-6xl mx-auto">
-            <h2 className="text-2xl font-bold mb-6">Related Articles</h2>
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-2xl font-bold">Related Articles</h2>
+              <Link
+                to="/blog"
+                className="text-sm text-emerald-600 hover:text-emerald-800 inline-flex items-center gap-1"
+              >
+                View all <ArrowRight className="w-4 h-4" aria-hidden="true" />
+              </Link>
+            </div>
             <div className="grid md:grid-cols-3 gap-6">
               {relatedPosts.map((relatedPost) => (
                 <BlogCard key={relatedPost.slug} post={relatedPost} />
@@ -336,8 +498,32 @@ export default function BlogPost() {
         </section>
       )}
 
+      {/* More from this category */}
+      {moreFromCategory.length > 0 && (
+        <section className="py-12 px-6 bg-gray-50 border-t border-gray-200">
+          <div className="max-w-6xl mx-auto">
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-2xl font-bold">
+                More in {categoryLabels[post.category]}
+              </h2>
+              <Link
+                to={`/blog?category=${post.category}`}
+                className="text-sm text-emerald-600 hover:text-emerald-800 inline-flex items-center gap-1"
+              >
+                See all <ArrowRight className="w-4 h-4" aria-hidden="true" />
+              </Link>
+            </div>
+            <div className="space-y-4">
+              {moreFromCategory.map((cp) => (
+                <BlogCard key={cp.slug} post={cp} variant="horizontal" />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
       {/* CTA Section */}
-      <section className="py-16 text-center bg-gradient-to-r from-emerald-600 to-emerald-600 text-white">
+      <section className="py-16 text-center bg-gradient-to-r from-emerald-600 to-emerald-700 text-white">
         <div className="max-w-3xl mx-auto px-6">
           <h2 className="text-3xl font-bold mb-4">Put This Knowledge to Use</h2>
           <p className="text-emerald-100 mb-8 text-lg">
@@ -366,5 +552,22 @@ export default function BlogPost() {
         </div>
       </section>
     </div>
+  );
+}
+
+// Article hero image with graceful fallback if the cover 404s.
+function CoverImage({ post }: { post: { coverImage?: string; title: string } }) {
+  const [errored, setErrored] = useState(false);
+  if (!post.coverImage || errored) return null;
+  return (
+    <img
+      src={post.coverImage}
+      alt={post.title}
+      onError={() => setErrored(true)}
+      onLoad={(e) => {
+        if (e.currentTarget.naturalWidth === 0) setErrored(true);
+      }}
+      className="w-full rounded-xl mb-8 object-cover"
+    />
   );
 }

--- a/vite-project/src/features/blog/components/BlogPost.tsx
+++ b/vite-project/src/features/blog/components/BlogPost.tsx
@@ -135,20 +135,34 @@ export default function BlogPost() {
           h2: ({ children }) => <h2 id={makeHeadingId(children)}>{children}</h2>,
           h3: ({ children }) => <h3 id={makeHeadingId(children)}>{children}</h3>,
           a: ({ href, children }) => {
-            const isInternal = href?.startsWith("/");
-            if (isInternal) {
+            const h = href || "";
+            // Internal route → client-side link.
+            if (h.startsWith("/")) {
               return (
                 <Link
-                  to={href || "/"}
+                  to={h}
                   className="text-emerald-600 hover:text-emerald-800"
                 >
                   {children}
                 </Link>
               );
             }
+            // In-page anchor → plain link, no new tab.
+            if (h.startsWith("#")) {
+              return (
+                <a href={h} className="text-emerald-600 hover:text-emerald-800">
+                  {children}
+                </a>
+              );
+            }
+            // Only render an href for safe protocols; otherwise degrade to text
+            // (guards against javascript:/data: URLs sneaking through markdown).
+            if (!/^(https?:\/\/|mailto:)/i.test(h)) {
+              return <span>{children}</span>;
+            }
             return (
               <a
-                href={href}
+                href={h}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-emerald-600 hover:text-emerald-800"

--- a/vite-project/src/features/blog/components/BlogSidebar.tsx
+++ b/vite-project/src/features/blog/components/BlogSidebar.tsx
@@ -1,0 +1,117 @@
+import { Link } from "react-router-dom";
+import { Flame, Layers, Hash, Sparkles } from "lucide-react";
+import { BlogCategory, categoryLabels, categoryColors } from "../types";
+import { getCategoryCounts, getPopularPosts, getAllTags } from "../utils";
+import BlogCard from "./BlogCard";
+
+interface BlogSidebarProps {
+  /** Slug of the post currently being read, so it's excluded from popular list. */
+  excludeSlug?: string;
+  /** Highlight the active category (list page). */
+  activeCategory?: BlogCategory | "all";
+  /** Max tags to show in the tag cloud. */
+  tagLimit?: number;
+}
+
+export default function BlogSidebar({
+  excludeSlug,
+  activeCategory,
+  tagLimit = 16,
+}: BlogSidebarProps) {
+  const categoryCounts = getCategoryCounts();
+  const popular = getPopularPosts(5, excludeSlug);
+  const tags = getAllTags().slice(0, tagLimit);
+
+  return (
+    <aside className="space-y-8">
+      {/* Categories */}
+      <div className="bg-white rounded-xl border border-gray-200 p-5">
+        <h3 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-900 mb-4">
+          <Layers className="w-4 h-4 text-emerald-600" />
+          Categories
+        </h3>
+        <ul className="space-y-1">
+          <li>
+            <Link
+              to="/blog"
+              className={`flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors ${
+                activeCategory === "all" || activeCategory === undefined
+                  ? "bg-emerald-50 text-emerald-700 font-semibold"
+                  : "text-gray-700 hover:bg-gray-50"
+              }`}
+            >
+              <span>All Articles</span>
+            </Link>
+          </li>
+          {categoryCounts.map(({ category, count }) => (
+            <li key={category}>
+              <Link
+                to={`/blog?category=${category}`}
+                className={`flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors ${
+                  activeCategory === category
+                    ? "bg-emerald-50 text-emerald-700 font-semibold"
+                    : "text-gray-700 hover:bg-gray-50"
+                }`}
+              >
+                <span>{categoryLabels[category]}</span>
+                <span
+                  className={`px-2 py-0.5 rounded-full text-xs font-medium ${categoryColors[category]}`}
+                >
+                  {count}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Popular posts */}
+      <div className="bg-white rounded-xl border border-gray-200 p-5">
+        <h3 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-900 mb-4">
+          <Flame className="w-4 h-4 text-orange-500" />
+          Popular Reads
+        </h3>
+        <div className="divide-y divide-gray-100">
+          {popular.map((post) => (
+            <BlogCard key={post.slug} post={post} variant="compact" />
+          ))}
+        </div>
+      </div>
+
+      {/* Tags */}
+      <div className="bg-white rounded-xl border border-gray-200 p-5">
+        <h3 className="flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-900 mb-4">
+          <Hash className="w-4 h-4 text-emerald-600" />
+          Browse by Topic
+        </h3>
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <Link
+              key={tag}
+              to={`/blog?search=${encodeURIComponent(tag)}`}
+              className="px-3 py-1 bg-gray-50 border border-gray-200 rounded-full text-xs text-gray-700 hover:border-emerald-300 hover:text-emerald-600 transition-all"
+            >
+              {tag}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* CTA card */}
+      <div className="rounded-xl bg-gradient-to-br from-emerald-600 to-emerald-700 p-6 text-white">
+        <Sparkles className="w-6 h-6 mb-3 text-emerald-100" />
+        <h3 className="text-lg font-bold mb-2">Train Smarter</h3>
+        <p className="text-sm text-emerald-100 mb-4">
+          Turn these tips into a plan with our free pace, VDOT, and fueling
+          calculators.
+        </p>
+        <Link
+          to="/calculator"
+          className="inline-flex items-center justify-center w-full px-4 py-2 bg-white text-emerald-700 rounded-lg text-sm font-semibold hover:bg-emerald-50 transition-colors"
+        >
+          Open Pace Calculator
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/vite-project/src/features/blog/index.ts
+++ b/vite-project/src/features/blog/index.ts
@@ -2,6 +2,7 @@
 export { default as BlogList } from "./components/BlogList";
 export { default as BlogPost } from "./components/BlogPost";
 export { default as BlogCard } from "./components/BlogCard";
+export { default as BlogSidebar } from "./components/BlogSidebar";
 
 // Types
 export * from "./types";

--- a/vite-project/src/features/blog/utils.ts
+++ b/vite-project/src/features/blog/utils.ts
@@ -103,3 +103,109 @@ export function getRelatedPosts(
 export function getAllPostSlugs(): string[] {
   return posts.map((post) => post.slug);
 }
+
+// Get the most recent posts (optionally excluding one slug)
+export function getRecentPosts(
+  limit: number = 5,
+  excludeSlug?: string
+): BlogPost[] {
+  return getAllPosts()
+    .filter((post) => post.slug !== excludeSlug)
+    .slice(0, limit);
+}
+
+// Get "popular" posts — featured first, then newest (optionally excluding one slug)
+export function getPopularPosts(
+  limit: number = 5,
+  excludeSlug?: string
+): BlogPost[] {
+  return getAllPosts()
+    .filter((post) => post.slug !== excludeSlug)
+    .sort((a, b) => {
+      const fa = a.featured ? 1 : 0;
+      const fb = b.featured ? 1 : 0;
+      if (fa !== fb) return fb - fa;
+      return new Date(b.date).getTime() - new Date(a.date).getTime();
+    })
+    .slice(0, limit);
+}
+
+// Get more posts from the same category (excluding the current post)
+export function getMoreFromCategory(
+  category: BlogCategory,
+  excludeSlug: string,
+  limit: number = 4
+): BlogPost[] {
+  return getAllPosts()
+    .filter((post) => post.category === category && post.slug !== excludeSlug)
+    .slice(0, limit);
+}
+
+// Count posts per category (for sidebar navigation)
+export function getCategoryCounts(): { category: BlogCategory; count: number }[] {
+  const counts = new Map<BlogCategory, number>();
+  posts.forEach((post) => {
+    counts.set(post.category, (counts.get(post.category) || 0) + 1);
+  });
+  return Array.from(counts.entries())
+    .map(([category, count]) => ({ category, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+// Drop a leading H1 from markdown so the page header can own the single H1.
+// Every post starts with "# Title", which would otherwise duplicate the header.
+export function stripLeadingH1(content: string): string {
+  const lines = content.split("\n");
+  let i = 0;
+  // Skip any leading blank lines
+  while (i < lines.length && lines[i].trim() === "") i++;
+  if (i < lines.length && /^#\s+/.test(lines[i])) {
+    lines.splice(0, i + 1);
+    // Also drop the blank line(s) immediately after the removed heading
+    while (lines.length && lines[0].trim() === "") lines.shift();
+    return lines.join("\n");
+  }
+  return content;
+}
+
+export interface TocHeading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+// Slugify heading text into an anchor id (mirrors what we set on rendered headings)
+export function slugifyHeading(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+// Extract h2/h3 headings from markdown content for a table of contents
+export function extractHeadings(content: string): TocHeading[] {
+  const headings: TocHeading[] = [];
+  const seen = new Map<string, number>();
+  // Only match top-level markdown headings, skip fenced code blocks
+  let inCodeBlock = false;
+  content.split("\n").forEach((line) => {
+    if (line.trim().startsWith("```")) {
+      inCodeBlock = !inCodeBlock;
+      return;
+    }
+    if (inCodeBlock) return;
+    const match = /^(#{2,3})\s+(.+?)\s*#*$/.exec(line);
+    if (!match) return;
+    const level = match[1].length;
+    const text = match[2].trim();
+    let id = slugifyHeading(text);
+    // Ensure unique ids for duplicate headings
+    const count = seen.get(id) || 0;
+    seen.set(id, count + 1);
+    if (count > 0) id = `${id}-${count}`;
+    headings.push({ id, text, level });
+  });
+  return headings;
+}


### PR DESCRIPTION
## Summary

Redesigns the blog list and post pages for easier browsing and more internal linking (more related articles), then fixes a batch of issues found in a self-review of the redesign.

### List page
- Magazine masthead, featured **hero** post, two-column layout with a **sidebar** (categories with counts, popular reads, tag cloud, CTA)
- **URL-driven** category filter + **live (debounced) search**, shareable via query params
- **"Load more"** pagination
- Sidebar now appears from the `md` breakpoint (was `lg`-only, so tablets got no sidebar)

### Post page
- **Reading-progress bar**, auto-generated **table of contents**, author box
- More related content: sidebar **"Popular Reads"** plus **"Related Articles"** and **"More in {category}"** sections — de-duplicated so no post repeats
- Strip the leading markdown `# H1` so the page header owns the single H1 (was rendering two identical H1s)
- Progress bar isolated into its own component + markdown memoized, so scrolling no longer re-renders the whole article

### BlogCard
- New `compact` and `horizontal` variants
- Image-less covers show a **category icon + label** instead of repeating the title; broken images fall back to the gradient (`onError` + zero-size `onLoad` guard)

### SEO (prerender.jsx)
- `/blog` and every `/blog/:slug` now prerender **real content**: per-post title, description, full article text, `BlogPosting` + breadcrumb JSON-LD, and `og:type=article`. Previously these routes fell through to generic landing content.

### Accessibility
- Search `aria-label`, `aria-hidden` on decorative icons, TOC focus styles, semantic headings

## Testing
- `npm run build` — passes (prerenders `/blog` + all 31 post routes with real content)
- `npm run lint` — 0 errors (no new warnings in changed files)
- Browser (Playwright) verification: no page errors across list, post, tablet, and search flows; confirmed single H1 per post, no in-card title duplication, de-duped related lists, live search, tablet sidebar, and broken-image fallback

## Notes
- The prerender static HTML uses a small built-in markdown→text converter (headings/lists/quotes/paragraphs, inline formatting stripped) rather than the full React renderer, to keep the prerender process Node-safe. The live app still renders the rich version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYmF15rTHdBZvH7RBEyamF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYmF15rTHdBZvH7RBEyamF)_