### PR TITLE
Training plan retention: redesign, persistence, progress tracking, mobile layout

### DIFF
--- a/vite-project/src/features/dashboard/components/TrainingPlanCard.tsx
+++ b/vite-project/src/features/dashboard/components/TrainingPlanCard.tsx
@@ -4,15 +4,18 @@ import type { TrainingPlan } from "../../plan/types";
 import { phaseColor } from "../../plan/plan-math";
 import { exportPlanAsIcal } from "../../plan/utils/exportIcal";
 import { WeekCard } from "../../plan/components/WeekCard";
+import { usePlanProgress } from "../../plan/hooks/usePlanProgress";
 
 interface Props {
   plan: TrainingPlan;
   onDelete: (id: string) => void;
+  userId?: string;
 }
 
-export function TrainingPlanCard({ plan, onDelete }: Props) {
+export function TrainingPlanCard({ plan, onDelete, userId }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [confirming, setConfirming] = useState(false);
+  const progress = usePlanProgress({ plan, planId: plan.id, userId });
 
   const raceDate = plan.raceDate
     ? new Date(plan.raceDate).toLocaleDateString("en-US", {
@@ -59,7 +62,23 @@ export function TrainingPlanCard({ plan, onDelete }: Props) {
                 <span className="text-emerald-600 font-medium">{weeksRemaining}w to go</span>
               </>
             )}
+            {progress.planProgress.totalCount > 0 && (
+              <>
+                <span>·</span>
+                <span className="font-medium tabular-nums">
+                  {progress.planProgress.completedCount}/{progress.planProgress.totalCount} runs
+                </span>
+              </>
+            )}
           </div>
+          {progress.planProgress.totalCount > 0 && (
+            <div className="mt-2 h-1 max-w-xs rounded-full bg-slate-100 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-emerald-500 transition-all"
+                style={{ width: `${progress.planProgress.pct}%` }}
+              />
+            </div>
+          )}
         </div>
 
         {/* Actions */}
@@ -152,7 +171,15 @@ export function TrainingPlanCard({ plan, onDelete }: Props) {
             </div>
             <div className="space-y-2 max-h-[600px] overflow-y-auto pr-1">
               {plan.weeks.map((week) => (
-                <WeekCard key={week.weekNumber} week={week} />
+                <WeekCard
+                  key={week.weekNumber}
+                  week={week}
+                  progress={{
+                    isComplete: (day) => progress.isComplete(week.weekNumber, day),
+                    onToggle: (day) => progress.toggle(week.weekNumber, day),
+                    pending: (day) => progress.isPending(week.weekNumber, day),
+                  }}
+                />
               ))}
             </div>
           </div>

--- a/vite-project/src/features/dashboard/components/TrainingPlansSection.tsx
+++ b/vite-project/src/features/dashboard/components/TrainingPlansSection.tsx
@@ -1,14 +1,36 @@
 import { Link } from "react-router-dom";
 import type { TrainingPlan } from "../../plan/types";
 import { TrainingPlanCard } from "./TrainingPlanCard";
+import { ThisWeekCard } from "../../plan/components/ThisWeekCard";
+import { usePlanProgress } from "../../plan/hooks/usePlanProgress";
+import { selectActivePlan } from "../../plan/utils/planSchedule";
 
 interface Props {
   plans: TrainingPlan[];
+  /** Unfiltered plan list (ignores search) — used to find the active plan for ThisWeekCard. */
+  allPlans: TrainingPlan[];
   loading: boolean;
   onDeletePlan: (id: string) => void;
+  userId?: string;
 }
 
-export function TrainingPlansSection({ plans, loading, onDeletePlan }: Props) {
+function ActiveWeekSummary({ plan, userId }: { plan: TrainingPlan; userId?: string }) {
+  const progress = usePlanProgress({ plan, planId: plan.id, userId });
+  return (
+    <ThisWeekCard
+      plan={plan}
+      currentWeekNumber={progress.currentWeekNumber}
+      nextWorkout={progress.nextWorkout}
+      planProgress={progress.planProgress}
+      weekProgress={progress.weekProgress}
+      isComplete={progress.isComplete}
+      onToggle={progress.toggle}
+      isPending={progress.isPending}
+    />
+  );
+}
+
+export function TrainingPlansSection({ plans, allPlans, loading, onDeletePlan, userId }: Props) {
   if (loading) {
     return (
       <div className="space-y-3">
@@ -37,10 +59,13 @@ export function TrainingPlansSection({ plans, loading, onDeletePlan }: Props) {
     );
   }
 
+  const activePlan = selectActivePlan(allPlans);
+
   return (
     <div className="space-y-3">
+      {activePlan && <ActiveWeekSummary plan={activePlan} userId={userId} />}
       {plans.map((plan) => (
-        <TrainingPlanCard key={plan.id} plan={plan} onDelete={onDeletePlan} />
+        <TrainingPlanCard key={plan.id} plan={plan} onDelete={onDeletePlan} userId={userId} />
       ))}
     </div>
   );

--- a/vite-project/src/features/plan/actions.ts
+++ b/vite-project/src/features/plan/actions.ts
@@ -1,0 +1,24 @@
+/**
+ * Training Plan — Firestore write actions (outside of hooks so they're easy
+ * to call from optimistic-update flows like usePlanProgress.toggle).
+ */
+
+import { doc, updateDoc, deleteField } from "firebase/firestore";
+import { db } from "../../lib/firebase";
+
+/**
+ * Toggle a single workout's completion state via a dot-path partial update
+ * (`completedWorkouts.${key}`), so concurrent devices toggling different
+ * workouts merge instead of clobbering each other's writes.
+ *
+ * Pass an ISO timestamp to mark complete, or `null` to clear it.
+ */
+export async function updateTrainingPlanProgress(
+  planId: string,
+  key: string,
+  value: string | null
+): Promise<void> {
+  await updateDoc(doc(db, "user_training_plans", planId), {
+    [`completedWorkouts.${key}`]: value ?? deleteField(),
+  });
+}

--- a/vite-project/src/features/plan/components/PlanCalendar.tsx
+++ b/vite-project/src/features/plan/components/PlanCalendar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { TrainingPlan } from "../types";
 import { WeekCard } from "./WeekCard";
 import type { PlanProgress } from "../hooks/usePlanProgress";
@@ -13,12 +13,32 @@ interface Props {
   savedId?: string | null;
   /** Omit for exact current read-only rendering (dashboard back-compat). */
   progress?: PlanProgress;
+  /**
+   * Whether this calendar is the currently-visible segment. When it first
+   * turns true, the current week's card is scrolled into view — once per
+   * mount, not on every toggle back to this segment.
+   */
+  isActive?: boolean;
 }
 
-export function PlanCalendar({ plan, onSave, saving, savedId, progress }: Props) {
+export function PlanCalendar({ plan, onSave, saving, savedId, progress, isActive }: Props) {
   const currentWeekNum = currentWeekNumber(plan);
   const [exported, setExported] = useState(false);
   const segments = phaseSegments(plan.weeks);
+  const currentWeekRef = useRef<HTMLDivElement>(null);
+  const hasScrolledRef = useRef(false);
+
+  useEffect(() => {
+    if (!isActive || hasScrolledRef.current || currentWeekNum === null) return;
+    hasScrolledRef.current = true;
+    const node = currentWeekRef.current;
+    if (!node) return;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    // Wait a tick so layout (e.g. the segment just becoming visible) settles first.
+    requestAnimationFrame(() => {
+      node.scrollIntoView({ block: "center", behavior: reduceMotion ? "auto" : "smooth" });
+    });
+  }, [isActive, currentWeekNum]);
 
   function handleExport() {
     exportPlanAsIcal(plan);
@@ -87,21 +107,25 @@ export function PlanCalendar({ plan, onSave, saving, savedId, progress }: Props)
               {plan.weeks
                 .filter((w) => w.weekNumber >= seg.startWeek && w.weekNumber <= seg.endWeek)
                 .map((week) => (
-                  <WeekCard
+                  <div
                     key={week.weekNumber}
-                    week={week}
-                    isCurrent={week.weekNumber === currentWeekNum}
-                    defaultOpen={week.weekNumber === 1 || week.weekNumber === currentWeekNum}
-                    progress={
-                      progress
-                        ? {
-                            isComplete: (day) => progress.isComplete(week.weekNumber, day),
-                            onToggle: (day) => progress.toggle(week.weekNumber, day),
-                            pending: (day) => progress.isPending(week.weekNumber, day),
-                          }
-                        : undefined
-                    }
-                  />
+                    ref={week.weekNumber === currentWeekNum ? currentWeekRef : undefined}
+                  >
+                    <WeekCard
+                      week={week}
+                      isCurrent={week.weekNumber === currentWeekNum}
+                      defaultOpen={week.weekNumber === 1 || week.weekNumber === currentWeekNum}
+                      progress={
+                        progress
+                          ? {
+                              isComplete: (day) => progress.isComplete(week.weekNumber, day),
+                              onToggle: (day) => progress.toggle(week.weekNumber, day),
+                              pending: (day) => progress.isPending(week.weekNumber, day),
+                            }
+                          : undefined
+                      }
+                    />
+                  </div>
                 ))}
             </div>
           </div>

--- a/vite-project/src/features/plan/components/PlanCalendar.tsx
+++ b/vite-project/src/features/plan/components/PlanCalendar.tsx
@@ -1,32 +1,22 @@
 import { useState } from "react";
 import type { TrainingPlan } from "../types";
 import { WeekCard } from "./WeekCard";
+import type { PlanProgress } from "../hooks/usePlanProgress";
 import { exportPlanAsIcal } from "../utils/exportIcal";
 import { phaseSegments, PHASE_META } from "../utils/planDisplay";
+import { currentWeekNumber } from "../utils/planSchedule";
 
 interface Props {
   plan: TrainingPlan;
   onSave?: () => void;
   saving?: boolean;
   savedId?: string | null;
+  /** Omit for exact current read-only rendering (dashboard back-compat). */
+  progress?: PlanProgress;
 }
 
-function currentWeekIndex(plan: TrainingPlan): number | null {
-  if (!plan.raceDate) return null;
-  const now = Date.now();
-  const raceMs = new Date(plan.raceDate).getTime();
-  if (now > raceMs) return null; // race is in the past
-
-  const msPerWeek = 7 * 24 * 60 * 60 * 1000;
-  const weeksUntilRace = Math.ceil((raceMs - now) / msPerWeek);
-  // Week index from end: plan.totalWeeks - weeksUntilRace
-  const idx = plan.totalWeeks - weeksUntilRace;
-  if (idx < 0 || idx >= plan.totalWeeks) return null;
-  return idx;
-}
-
-export function PlanCalendar({ plan, onSave, saving, savedId }: Props) {
-  const currentIdx = currentWeekIndex(plan);
+export function PlanCalendar({ plan, onSave, saving, savedId, progress }: Props) {
+  const currentWeekNum = currentWeekNumber(plan);
   const [exported, setExported] = useState(false);
   const segments = phaseSegments(plan.weeks);
 
@@ -71,9 +61,10 @@ export function PlanCalendar({ plan, onSave, saving, savedId }: Props) {
         </div>
       </div>
 
-      {currentIdx !== null && (
+      {currentWeekNum !== null && (
         <div className="rounded-xl bg-emerald-50 border border-emerald-200 px-4 py-2.5 text-sm text-emerald-800 font-medium">
-          📍 You are on <strong>Week {currentIdx + 1}</strong> — {plan.weeks[currentIdx]?.phase}
+          📍 You are on <strong>Week {currentWeekNum}</strong> —{" "}
+          {plan.weeks.find((w) => w.weekNumber === currentWeekNum)?.phase}
         </div>
       )}
 
@@ -99,8 +90,17 @@ export function PlanCalendar({ plan, onSave, saving, savedId }: Props) {
                   <WeekCard
                     key={week.weekNumber}
                     week={week}
-                    isCurrent={week.weekNumber - 1 === currentIdx}
-                    defaultOpen={week.weekNumber === 1 || week.weekNumber - 1 === currentIdx}
+                    isCurrent={week.weekNumber === currentWeekNum}
+                    defaultOpen={week.weekNumber === 1 || week.weekNumber === currentWeekNum}
+                    progress={
+                      progress
+                        ? {
+                            isComplete: (day) => progress.isComplete(week.weekNumber, day),
+                            onToggle: (day) => progress.toggle(week.weekNumber, day),
+                            pending: (day) => progress.isPending(week.weekNumber, day),
+                          }
+                        : undefined
+                    }
                   />
                 ))}
             </div>

--- a/vite-project/src/features/plan/components/PlanCalendar.tsx
+++ b/vite-project/src/features/plan/components/PlanCalendar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { TrainingPlan } from "../types";
 import { WeekCard } from "./WeekCard";
 import { exportPlanAsIcal } from "../utils/exportIcal";
+import { phaseSegments, PHASE_META } from "../utils/planDisplay";
 
 interface Props {
   plan: TrainingPlan;
@@ -27,6 +28,7 @@ function currentWeekIndex(plan: TrainingPlan): number | null {
 export function PlanCalendar({ plan, onSave, saving, savedId }: Props) {
   const currentIdx = currentWeekIndex(plan);
   const [exported, setExported] = useState(false);
+  const segments = phaseSegments(plan.weeks);
 
   function handleExport() {
     exportPlanAsIcal(plan);
@@ -75,13 +77,34 @@ export function PlanCalendar({ plan, onSave, saving, savedId }: Props) {
         </div>
       )}
 
-      <div className="space-y-3">
-        {plan.weeks.map((week, i) => (
-          <WeekCard
-            key={week.weekNumber}
-            week={week}
-            isCurrent={i === currentIdx}
-          />
+      <div className="space-y-6">
+        {segments.map((seg) => (
+          <div key={`${seg.phase}-${seg.startWeek}`} className="space-y-3">
+            <div className="flex items-center gap-2 px-1">
+              <span
+                className="h-2.5 w-2.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: PHASE_META[seg.phase].bg }}
+              />
+              <h4 className="text-sm font-bold text-slate-800">{seg.phase}</h4>
+              <span className="text-xs font-mono text-slate-400">
+                {seg.startWeek === seg.endWeek
+                  ? `Week ${seg.startWeek}`
+                  : `Weeks ${seg.startWeek}–${seg.endWeek}`}
+              </span>
+            </div>
+            <div className="space-y-3">
+              {plan.weeks
+                .filter((w) => w.weekNumber >= seg.startWeek && w.weekNumber <= seg.endWeek)
+                .map((week) => (
+                  <WeekCard
+                    key={week.weekNumber}
+                    week={week}
+                    isCurrent={week.weekNumber - 1 === currentIdx}
+                    defaultOpen={week.weekNumber === 1 || week.weekNumber - 1 === currentIdx}
+                  />
+                ))}
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/vite-project/src/features/plan/components/PlanInputForm.tsx
+++ b/vite-project/src/features/plan/components/PlanInputForm.tsx
@@ -21,13 +21,29 @@ interface Props {
   prefillGoalTime?: string;
   prefillGoalRace?: GoalRace;
   prefillSource?: "calculator" | "vdot";
+  /** Previously-entered values restored from a persisted draft (see planPersistence.ts). */
+  prefillRaceDate?: string;
+  prefillFitness?: FitnessLevel;
+  prefillDays?: RunDay[];
 }
 
-export function PlanInputForm({ onGenerate, loading, prefillPaces, prefillGoalTime, prefillGoalRace, prefillSource }: Props) {
+export function PlanInputForm({
+  onGenerate,
+  loading,
+  prefillPaces,
+  prefillGoalTime,
+  prefillGoalRace,
+  prefillSource,
+  prefillRaceDate,
+  prefillFitness,
+  prefillDays,
+}: Props) {
   const [goalRace, setGoalRace] = useState<GoalRace>(prefillGoalRace ?? "Half Marathon");
-  const [raceDate, setRaceDate] = useState("");
-  const [fitness, setFitness] = useState<FitnessLevel>("intermediate");
-  const [days, setDays] = useState<RunDay[]>(["Tue", "Thu", "Sat", "Sun"]);
+  const [raceDate, setRaceDate] = useState(prefillRaceDate ?? "");
+  const [fitness, setFitness] = useState<FitnessLevel>(prefillFitness ?? "intermediate");
+  const [days, setDays] = useState<RunDay[]>(
+    prefillDays && prefillDays.length > 0 ? prefillDays : ["Tue", "Thu", "Sat", "Sun"]
+  );
   const [goalTime, setGoalTime] = useState(prefillGoalTime ?? "");
 
   function toggleDay(day: RunDay) {

--- a/vite-project/src/features/plan/components/PlanInputForm.tsx
+++ b/vite-project/src/features/plan/components/PlanInputForm.tsx
@@ -84,8 +84,8 @@ export function PlanInputForm({ onGenerate, loading, prefillPaces, prefillGoalTi
               onClick={() => setGoalRace(r)}
               className={`rounded-xl border-2 px-4 py-3 text-sm font-semibold transition-all ${
                 goalRace === r
-                  ? "border-emerald-500 bg-emerald-50 text-emerald-700"
-                  : "border-slate-200 bg-white text-slate-700 hover:border-emerald-300"
+                  ? "border-emerald-600 bg-emerald-600 text-white shadow-md shadow-emerald-600/20"
+                  : "border-slate-200 bg-white text-slate-700 hover:border-emerald-300 hover:bg-emerald-50/60"
               }`}
             >
               {r}
@@ -99,14 +99,26 @@ export function PlanInputForm({ onGenerate, loading, prefillPaces, prefillGoalTi
         <label className="block text-sm font-semibold text-slate-700 mb-3">
           Race Date
         </label>
-        <input
-          type="date"
-          required
-          min={minDateStr}
-          value={raceDate}
-          onChange={(e) => setRaceDate(e.target.value)}
-          className="w-full sm:w-64 rounded-xl border-2 border-slate-200 px-4 py-3 text-sm font-medium text-slate-800 focus:outline-none focus:border-emerald-500 transition-colors"
-        />
+        <div className="relative w-full sm:w-64">
+          <svg
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-emerald-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <input
+            type="date"
+            required
+            min={minDateStr}
+            value={raceDate}
+            onChange={(e) => setRaceDate(e.target.value)}
+            className="w-full rounded-xl border-2 border-slate-200 pl-11 pr-4 py-3 text-sm font-medium text-slate-800 focus:outline-none focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 transition-all"
+          />
+        </div>
       </div>
 
       {/* Fitness Level */}
@@ -122,14 +134,14 @@ export function PlanInputForm({ onGenerate, loading, prefillPaces, prefillGoalTi
               onClick={() => setFitness(value)}
               className={`rounded-xl border-2 px-4 py-4 text-left transition-all ${
                 fitness === value
-                  ? "border-emerald-500 bg-emerald-50"
-                  : "border-slate-200 bg-white hover:border-emerald-300"
+                  ? "border-emerald-600 bg-emerald-600 shadow-md shadow-emerald-600/20"
+                  : "border-slate-200 bg-white hover:border-emerald-300 hover:bg-emerald-50/60"
               }`}
             >
-              <div className={`text-sm font-bold mb-1 ${fitness === value ? "text-emerald-700" : "text-slate-800"}`}>
+              <div className={`text-sm font-bold mb-1 ${fitness === value ? "text-white" : "text-slate-800"}`}>
                 {label}
               </div>
-              <div className="text-xs text-slate-500">{desc}</div>
+              <div className={`text-xs ${fitness === value ? "text-emerald-50" : "text-slate-500"}`}>{desc}</div>
             </button>
           ))}
         </div>
@@ -148,8 +160,8 @@ export function PlanInputForm({ onGenerate, loading, prefillPaces, prefillGoalTi
               onClick={() => toggleDay(day)}
               className={`w-14 h-12 rounded-xl border-2 text-sm font-bold transition-all ${
                 days.includes(day)
-                  ? "border-emerald-500 bg-emerald-500 text-white"
-                  : "border-slate-200 bg-white text-slate-700 hover:border-emerald-300"
+                  ? "border-emerald-600 bg-emerald-600 text-white shadow-md shadow-emerald-600/20"
+                  : "border-slate-200 bg-white text-slate-700 hover:border-emerald-300 hover:bg-emerald-50/60"
               }`}
             >
               {day}
@@ -178,17 +190,26 @@ export function PlanInputForm({ onGenerate, loading, prefillPaces, prefillGoalTi
           placeholder="e.g. 1:45:00"
           value={goalTime}
           onChange={(e) => setGoalTime(e.target.value)}
-          className="w-48 rounded-xl border-2 border-slate-200 px-4 py-3 text-sm font-medium text-slate-800 focus:outline-none focus:border-emerald-500 transition-colors"
+          className="w-48 rounded-xl border-2 border-slate-200 px-4 py-3 text-sm font-mono font-medium text-slate-800 focus:outline-none focus:border-emerald-500 focus:ring-4 focus:ring-emerald-100 transition-all"
         />
       </div>
 
-      <button
-        type="submit"
-        disabled={loading || days.length < 2 || !raceDate}
-        className="w-full sm:w-auto rounded-xl bg-emerald-600 hover:bg-emerald-700 disabled:bg-slate-300 disabled:cursor-not-allowed text-white font-bold px-8 py-4 text-base transition-colors shadow-sm"
-      >
-        {loading ? "Generating…" : "Generate My Plan →"}
-      </button>
+      <div>
+        <button
+          type="submit"
+          disabled={loading || days.length < 2 || !raceDate}
+          className="w-full sm:w-auto rounded-xl bg-emerald-600 hover:bg-emerald-700 disabled:bg-slate-100 disabled:text-slate-400 disabled:shadow-none disabled:cursor-not-allowed text-white font-bold px-8 py-4 text-base transition-all shadow-md shadow-emerald-600/20"
+        >
+          {loading ? "Generating…" : "Generate My Plan →"}
+        </button>
+        {!loading && (days.length < 2 || !raceDate) && (
+          <p className="mt-2 text-xs text-slate-400">
+            {!raceDate
+              ? "Pick a race date to continue."
+              : "Select at least 2 training days to continue."}
+          </p>
+        )}
+      </div>
     </form>
   );
 }

--- a/vite-project/src/features/plan/components/PlanOverview.tsx
+++ b/vite-project/src/features/plan/components/PlanOverview.tsx
@@ -1,6 +1,7 @@
 import type { TrainingPlan, TrainingWeek } from "../types";
 import { weeksUntilRace } from "../plan-math";
 import { PHASE_META, PACE_ZONE_ORDER, phaseSegments, parsePlanGoalTime } from "../utils/planDisplay";
+import type { ProgressSummary } from "../hooks/usePlanProgress";
 import { cn } from "@/lib/utils";
 
 function VolumeChart({ weeks }: { weeks: TrainingWeek[] }) {
@@ -52,9 +53,11 @@ function VolumeChart({ weeks }: { weeks: TrainingWeek[] }) {
 
 interface Props {
   plan: TrainingPlan;
+  /** Omit to hide the progress tile — shown once a plan has been generated/saved. */
+  progress?: ProgressSummary;
 }
 
-export function PlanOverview({ plan }: Props) {
+export function PlanOverview({ plan, progress }: Props) {
   const totalKm = plan.weeks.reduce((s, w) => s + w.totalKm, 0);
   const peakKm = Math.max(...plan.weeks.map((w) => w.totalKm));
   const segments = phaseSegments(plan.weeks);
@@ -109,6 +112,26 @@ export function PlanOverview({ plan }: Props) {
               {weeksLeft > 0 ? `${weeksLeft} weeks to go` : "Race week!"}
             </span>
           </p>
+
+          {/* Progress */}
+          {progress && progress.totalCount > 0 && (
+            <div className="mt-5 rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm px-4 py-3 sm:px-5 sm:py-4">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Plan Progress
+                </span>
+                <span className="font-display text-sm font-bold text-emerald-300 tabular-nums">
+                  {progress.completedCount}/{progress.totalCount} runs · {progress.pct}%
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-white/10 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-emerald-400 transition-all"
+                  style={{ width: `${progress.pct}%` }}
+                />
+              </div>
+            </div>
+          )}
 
           {/* Stat tiles */}
           <div className="mt-6 grid grid-cols-3 gap-2 sm:gap-3">

--- a/vite-project/src/features/plan/components/PlanOverview.tsx
+++ b/vite-project/src/features/plan/components/PlanOverview.tsx
@@ -1,63 +1,18 @@
-import type { TrainingPlan, TrainingWeek } from "../types";
+import type { TrainingPlan } from "../types";
 import { weeksUntilRace } from "../plan-math";
-import { PHASE_META, PACE_ZONE_ORDER, phaseSegments, parsePlanGoalTime } from "../utils/planDisplay";
-import type { ProgressSummary } from "../hooks/usePlanProgress";
-import { cn } from "@/lib/utils";
-
-function VolumeChart({ weeks }: { weeks: TrainingWeek[] }) {
-  const maxKm = Math.max(...weeks.map((w) => w.totalKm), 1);
-  const peakIdx = weeks.reduce((best, w, i) => (w.totalKm > weeks[best].totalKm ? i : best), 0);
-
-  return (
-    <div>
-      <div className="flex items-baseline justify-between mb-3">
-        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
-          Weekly Volume
-        </div>
-        <div className="text-xs text-slate-400">{weeks.length} weeks</div>
-      </div>
-      <div className="relative h-28 sm:h-32 pt-5">
-        <div
-          className="absolute top-0 text-[9px] font-bold uppercase tracking-wide text-emerald-600 whitespace-nowrap"
-          style={{ left: `${((peakIdx + 0.5) / weeks.length) * 100}%`, transform: "translateX(-50%)" }}
-        >
-          Peak
-        </div>
-        <div className="absolute inset-x-0 bottom-0 top-5 flex items-end gap-[3px]">
-          {weeks.map((w, i) => {
-            const pct = Math.max((w.totalKm / maxKm) * 100, 4);
-            const meta = PHASE_META[w.phase];
-            const isPeak = i === peakIdx;
-            return (
-              <div key={w.weekNumber} className="relative flex-1 min-w-0 h-full">
-                <div
-                  className={cn(
-                    "absolute bottom-0 inset-x-0 rounded-t-sm transition-all",
-                    isPeak && "ring-2 ring-emerald-400"
-                  )}
-                  style={{ height: `${pct}%`, backgroundColor: meta.bg }}
-                  title={`Week ${w.weekNumber} · ${w.totalKm} km · ${w.phase}`}
-                />
-              </div>
-            );
-          })}
-        </div>
-      </div>
-      <div className="flex justify-between mt-2 text-[10px] font-mono text-slate-400">
-        <span>Wk 1</span>
-        <span>Wk {weeks.length}</span>
-      </div>
-    </div>
-  );
-}
+import { PHASE_META, phaseSegments, parsePlanGoalTime } from "../utils/planDisplay";
 
 interface Props {
   plan: TrainingPlan;
-  /** Omit to hide the progress tile — shown once a plan has been generated/saved. */
-  progress?: ProgressSummary;
 }
 
-export function PlanOverview({ plan, progress }: Props) {
+/**
+ * Lean plan hero — race name, goal time, countdown, the 3 stat tiles, and a
+ * slim phase bar. Stays above the segmented view on every breakpoint. The
+ * weekly volume chart, pace zone cards, and the full phase timeline (labels
+ * + legend) live in PlanStats now — see PlanStats.tsx.
+ */
+export function PlanOverview({ plan }: Props) {
   const totalKm = plan.weeks.reduce((s, w) => s + w.totalKm, 0);
   const peakKm = Math.max(...plan.weeks.map((w) => w.totalKm));
   const segments = phaseSegments(plan.weeks);
@@ -72,189 +27,82 @@ export function PlanOverview({ plan, progress }: Props) {
   });
 
   return (
-    <div className="space-y-4">
-      {/* ── Hero ─────────────────────────────────────────────────────── */}
-      <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-900 to-emerald-950 p-6 sm:p-8 shadow-xl">
-        {/* decorative glow */}
-        <div className="pointer-events-none absolute -top-24 -right-16 h-64 w-64 rounded-full bg-emerald-500/20 blur-3xl" />
-        <div className="pointer-events-none absolute -bottom-28 -left-20 h-64 w-64 rounded-full bg-emerald-400/10 blur-3xl" />
+    <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-900 to-emerald-950 p-5 sm:p-8 shadow-xl">
+      {/* decorative glow */}
+      <div className="pointer-events-none absolute -top-24 -right-16 h-64 w-64 rounded-full bg-emerald-500/20 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-28 -left-20 h-64 w-64 rounded-full bg-emerald-400/10 blur-3xl" />
 
-        <div className="relative">
-          <div className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-emerald-300">
-            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-            {plan.totalWeeks}-Week Plan
-          </div>
+      <div className="relative">
+        <div className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-emerald-300">
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+          {plan.totalWeeks}-Week Plan
+        </div>
 
-          <h2 className="mt-3 font-display text-2xl sm:text-3xl font-bold text-white tracking-tight">
-            {plan.goalRace}
-          </h2>
+        <h2 className="mt-3 font-display text-2xl sm:text-3xl font-bold text-white tracking-tight">
+          {plan.goalRace}
+        </h2>
 
-          {goalTime ? (
-            <div className="mt-1 flex items-baseline gap-2">
-              <span className="font-display text-4xl sm:text-5xl font-bold text-emerald-300 tabular-nums tracking-tight">
-                {goalTime}
-              </span>
-              <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
-                Goal Time
-              </span>
-            </div>
-          ) : (
-            <div className="mt-1 text-sm font-medium text-slate-300 capitalize">
-              {plan.fitnessLevel} fitness plan
-            </div>
-          )}
-
-          <p className="mt-3 text-sm text-slate-300">
-            Race day{" "}
-            <span className="font-semibold text-white">{raceDateLabel}</span>
-            {" · "}
-            <span className="font-semibold text-emerald-300">
-              {weeksLeft > 0 ? `${weeksLeft} weeks to go` : "Race week!"}
+        {goalTime ? (
+          <div className="mt-1 flex items-baseline gap-2">
+            <span className="font-display text-4xl sm:text-5xl font-bold text-emerald-300 tabular-nums tracking-tight">
+              {goalTime}
             </span>
-          </p>
-
-          {/* Progress */}
-          {progress && progress.totalCount > 0 && (
-            <div className="mt-5 rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm px-4 py-3 sm:px-5 sm:py-4">
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
-                  Plan Progress
-                </span>
-                <span className="font-display text-sm font-bold text-emerald-300 tabular-nums">
-                  {progress.completedCount}/{progress.totalCount} runs · {progress.pct}%
-                </span>
-              </div>
-              <div className="h-2 rounded-full bg-white/10 overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-emerald-400 transition-all"
-                  style={{ width: `${progress.pct}%` }}
-                />
-              </div>
-            </div>
-          )}
-
-          {/* Stat tiles */}
-          <div className="mt-6 grid grid-cols-3 gap-2 sm:gap-3">
-            {[
-              { label: "Total Weeks", value: `${plan.totalWeeks}` },
-              { label: "Total Volume", value: `${totalKm}`, unit: "km" },
-              { label: "Peak Week", value: `${peakKm}`, unit: "km" },
-            ].map(({ label, value, unit }) => (
-              <div
-                key={label}
-                className="rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm px-2 py-3 sm:px-4 sm:py-4 text-center"
-              >
-                <div className="font-display text-xl sm:text-3xl font-bold text-white tabular-nums">
-                  {value}
-                  {unit && <span className="ml-0.5 text-xs sm:text-sm font-semibold text-slate-400">{unit}</span>}
-                </div>
-                <div className="mt-1 text-[9px] sm:text-xs font-semibold uppercase tracking-wide text-slate-400">
-                  {label}
-                </div>
-              </div>
-            ))}
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Goal Time
+            </span>
           </div>
-
-          {/* Phase timeline */}
-          <div className="mt-6">
-            <div className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
-              Plan Structure
-            </div>
-            <div className="flex h-3 rounded-full overflow-hidden">
-              {segments.map((seg, i) => (
-                <div
-                  key={`${seg.phase}-${seg.startWeek}`}
-                  style={{
-                    flexGrow: seg.count,
-                    backgroundColor: PHASE_META[seg.phase].bg,
-                  }}
-                  title={`${seg.phase}: weeks ${seg.startWeek}–${seg.endWeek}`}
-                  className={cn(
-                    "h-full transition-all hover:brightness-110",
-                    i > 0 && "border-l border-slate-900/40"
-                  )}
-                />
-              ))}
-            </div>
-
-            {/* inline labels — sm and up */}
-            <div className="hidden sm:flex mt-2 gap-1">
-              {segments.map((seg) => (
-                <div
-                  key={`lbl-${seg.phase}-${seg.startWeek}`}
-                  style={{ flexGrow: seg.count }}
-                  className="min-w-0"
-                >
-                  {seg.count >= 2 && (
-                    <>
-                      <div className="truncate text-xs font-bold text-white">
-                        {seg.phase}
-                      </div>
-                      <div className="text-[10px] font-mono text-slate-400">
-                        Wk {seg.startWeek}–{seg.endWeek}
-                      </div>
-                    </>
-                  )}
-                </div>
-              ))}
-            </div>
-
-            {/* compact legend — mobile only, never clips */}
-            <div className="flex sm:hidden flex-wrap gap-x-4 gap-y-1.5 mt-3">
-              {segments.map((seg) => (
-                <div
-                  key={`legend-${seg.phase}-${seg.startWeek}`}
-                  className="flex items-center gap-1.5 text-xs text-slate-300"
-                >
-                  <span
-                    className="h-2 w-2 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: PHASE_META[seg.phase].bg }}
-                  />
-                  {seg.phase}
-                  <span className="text-slate-500">({seg.count}w)</span>
-                </div>
-              ))}
-            </div>
+        ) : (
+          <div className="mt-1 text-sm font-medium text-slate-300 capitalize">
+            {plan.fitnessLevel} fitness plan
           </div>
-        </div>
-      </div>
+        )}
 
-      {/* ── Weekly volume ────────────────────────────────────────────── */}
-      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-5 sm:p-6">
-        <VolumeChart weeks={plan.weeks} />
-      </div>
+        <p className="mt-3 text-sm text-slate-300">
+          Race day{" "}
+          <span className="font-semibold text-white">{raceDateLabel}</span>
+          {" · "}
+          <span className="font-semibold text-emerald-300">
+            {weeksLeft > 0 ? `${weeksLeft} weeks to go` : "Race week!"}
+          </span>
+        </p>
 
-      {/* ── Pace zones ───────────────────────────────────────────────── */}
-      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-5 sm:p-6">
-        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-3">
-          Training Paces
-        </div>
-        <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
-          {PACE_ZONE_ORDER.map(({ key, label, bg, text }) => (
+        {/* Stat tiles */}
+        <div className="mt-4 sm:mt-6 grid grid-cols-3 gap-2 sm:gap-3">
+          {[
+            { label: "Total Weeks", value: `${plan.totalWeeks}` },
+            { label: "Total Volume", value: `${totalKm}`, unit: "km" },
+            { label: "Peak Week", value: `${peakKm}`, unit: "km" },
+          ].map(({ label, value, unit }) => (
             <div
-              key={key}
-              className="rounded-xl overflow-hidden border border-slate-100 flex"
+              key={label}
+              className="rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm px-2 py-3 sm:px-4 sm:py-4 text-center"
             >
-              <div className="w-1.5 flex-shrink-0" style={{ backgroundColor: bg }} />
-              <div
-                className="flex-1 px-2.5 py-2.5 sm:px-3 sm:py-3 text-center"
-                style={{ backgroundColor: `${bg}1a` }}
-              >
-                <div
-                  className="text-sm sm:text-base font-bold font-mono tabular-nums"
-                  style={{ color: text }}
-                >
-                  {plan.paces[key]}
-                  <span className="ml-0.5 text-[10px] font-semibold text-slate-400">
-                    /km
-                  </span>
-                </div>
-                <div className="mt-0.5 text-[10px] sm:text-xs font-semibold text-slate-500 uppercase tracking-wide">
-                  {label}
-                </div>
+              <div className="font-display text-xl sm:text-3xl font-bold text-white tabular-nums">
+                {value}
+                {unit && <span className="ml-0.5 text-xs sm:text-sm font-semibold text-slate-400">{unit}</span>}
+              </div>
+              <div className="mt-1 text-[9px] sm:text-xs font-semibold uppercase tracking-wide text-slate-400">
+                {label}
               </div>
             </div>
           ))}
+        </div>
+
+        {/* Slim phase bar — full breakdown with labels/legend lives in the Stats segment */}
+        <div className="mt-4 sm:mt-6">
+          <div className="flex h-2.5 rounded-full overflow-hidden">
+            {segments.map((seg, i) => (
+              <div
+                key={`${seg.phase}-${seg.startWeek}`}
+                style={{
+                  flexGrow: seg.count,
+                  backgroundColor: PHASE_META[seg.phase].bg,
+                }}
+                title={`${seg.phase}: weeks ${seg.startWeek}–${seg.endWeek}`}
+                className={i > 0 ? "h-full border-l border-slate-900/40" : "h-full"}
+              />
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/vite-project/src/features/plan/components/PlanOverview.tsx
+++ b/vite-project/src/features/plan/components/PlanOverview.tsx
@@ -1,54 +1,51 @@
-import type { TrainingPlan, TrainingPhase, TrainingWeek } from "../types";
-import { phaseColor } from "../plan-math";
+import type { TrainingPlan, TrainingWeek } from "../types";
+import { weeksUntilRace } from "../plan-math";
+import { PHASE_META, PACE_ZONE_ORDER, phaseSegments, parsePlanGoalTime } from "../utils/planDisplay";
+import { cn } from "@/lib/utils";
 
 function VolumeChart({ weeks }: { weeks: TrainingWeek[] }) {
-  const maxKm = Math.max(...weeks.map((w) => w.totalKm));
-  const chartH = 80;
-  const barW = Math.max(4, Math.floor(540 / weeks.length) - 2);
+  const maxKm = Math.max(...weeks.map((w) => w.totalKm), 1);
+  const peakIdx = weeks.reduce((best, w, i) => (w.totalKm > weeks[best].totalKm ? i : best), 0);
 
   return (
     <div>
-      <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-3">
-        Weekly Volume
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
+          Weekly Volume
+        </div>
+        <div className="text-xs text-slate-400">{weeks.length} weeks</div>
       </div>
-      <div className="overflow-x-auto">
-        <svg
-          width={weeks.length * (barW + 2)}
-          height={chartH + 24}
-          className="block"
+      <div className="relative h-28 sm:h-32 pt-5">
+        <div
+          className="absolute top-0 text-[9px] font-bold uppercase tracking-wide text-emerald-600 whitespace-nowrap"
+          style={{ left: `${((peakIdx + 0.5) / weeks.length) * 100}%`, transform: "translateX(-50%)" }}
         >
+          Peak
+        </div>
+        <div className="absolute inset-x-0 bottom-0 top-5 flex items-end gap-[3px]">
           {weeks.map((w, i) => {
-            const barH = Math.round((w.totalKm / maxKm) * chartH);
-            const x = i * (barW + 2);
-            const y = chartH - barH;
-            const color = phaseColor(w.phase);
+            const pct = Math.max((w.totalKm / maxKm) * 100, 4);
+            const meta = PHASE_META[w.phase];
+            const isPeak = i === peakIdx;
             return (
-              <g key={w.weekNumber}>
-                <rect
-                  x={x}
-                  y={y}
-                  width={barW}
-                  height={barH}
-                  rx={2}
-                  fill={color}
+              <div key={w.weekNumber} className="relative flex-1 min-w-0 h-full">
+                <div
+                  className={cn(
+                    "absolute bottom-0 inset-x-0 rounded-t-sm transition-all",
+                    isPeak && "ring-2 ring-emerald-400"
+                  )}
+                  style={{ height: `${pct}%`, backgroundColor: meta.bg }}
+                  title={`Week ${w.weekNumber} · ${w.totalKm} km · ${w.phase}`}
                 />
-                {weeks.length <= 20 && (
-                  <text
-                    x={x + barW / 2}
-                    y={chartH + 14}
-                    textAnchor="middle"
-                    fontSize={9}
-                    fill="#94a3b8"
-                  >
-                    {w.weekNumber}
-                  </text>
-                )}
-              </g>
+              </div>
             );
           })}
-        </svg>
+        </div>
       </div>
-      <div className="text-xs text-slate-400 mt-1">Week number · height = km</div>
+      <div className="flex justify-between mt-2 text-[10px] font-mono text-slate-400">
+        <span>Wk 1</span>
+        <span>Wk {weeks.length}</span>
+      </div>
     </div>
   );
 }
@@ -58,108 +55,181 @@ interface Props {
 }
 
 export function PlanOverview({ plan }: Props) {
-  const phaseSummary = plan.weeks.reduce<Record<TrainingPhase, number>>(
-    (acc, w) => {
-      acc[w.phase] = (acc[w.phase] || 0) + 1;
-      return acc;
-    },
-    {} as Record<TrainingPhase, number>
-  );
-
   const totalKm = plan.weeks.reduce((s, w) => s + w.totalKm, 0);
   const peakKm = Math.max(...plan.weeks.map((w) => w.totalKm));
+  const segments = phaseSegments(plan.weeks);
+  const goalTime = parsePlanGoalTime(plan.name);
+  const weeksLeft = weeksUntilRace(plan.raceDate);
+
+  const raceDateLabel = new Date(plan.raceDate).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
 
   return (
-    <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-6 space-y-6">
-      {/* Header */}
-      <div>
-        <h2 className="text-xl font-bold text-slate-900">{plan.name}</h2>
-        <p className="text-sm text-slate-500 mt-1">
-          {plan.totalWeeks} weeks · Race:{" "}
-          {new Date(plan.raceDate).toLocaleDateString("en-US", {
-            month: "long",
-            day: "numeric",
-            year: "numeric",
-          })}
-        </p>
-      </div>
+    <div className="space-y-4">
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-900 to-emerald-950 p-6 sm:p-8 shadow-xl">
+        {/* decorative glow */}
+        <div className="pointer-events-none absolute -top-24 -right-16 h-64 w-64 rounded-full bg-emerald-500/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-28 -left-20 h-64 w-64 rounded-full bg-emerald-400/10 blur-3xl" />
 
-      {/* Stats row */}
-      <div className="grid grid-cols-3 gap-4">
-        {[
-          { label: "Total Weeks", value: plan.totalWeeks },
-          { label: "Total Volume", value: `${totalKm} km` },
-          { label: "Peak Week", value: `${peakKm} km` },
-        ].map(({ label, value }) => (
-          <div key={label} className="bg-slate-50 rounded-xl p-4 text-center">
-            <div className="text-2xl font-bold text-emerald-600">{value}</div>
-            <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mt-1">
-              {label}
+        <div className="relative">
+          <div className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-emerald-300">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+            {plan.totalWeeks}-Week Plan
+          </div>
+
+          <h2 className="mt-3 font-display text-2xl sm:text-3xl font-bold text-white tracking-tight">
+            {plan.goalRace}
+          </h2>
+
+          {goalTime ? (
+            <div className="mt-1 flex items-baseline gap-2">
+              <span className="font-display text-4xl sm:text-5xl font-bold text-emerald-300 tabular-nums tracking-tight">
+                {goalTime}
+              </span>
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                Goal Time
+              </span>
+            </div>
+          ) : (
+            <div className="mt-1 text-sm font-medium text-slate-300 capitalize">
+              {plan.fitnessLevel} fitness plan
+            </div>
+          )}
+
+          <p className="mt-3 text-sm text-slate-300">
+            Race day{" "}
+            <span className="font-semibold text-white">{raceDateLabel}</span>
+            {" · "}
+            <span className="font-semibold text-emerald-300">
+              {weeksLeft > 0 ? `${weeksLeft} weeks to go` : "Race week!"}
+            </span>
+          </p>
+
+          {/* Stat tiles */}
+          <div className="mt-6 grid grid-cols-3 gap-2 sm:gap-3">
+            {[
+              { label: "Total Weeks", value: `${plan.totalWeeks}` },
+              { label: "Total Volume", value: `${totalKm}`, unit: "km" },
+              { label: "Peak Week", value: `${peakKm}`, unit: "km" },
+            ].map(({ label, value, unit }) => (
+              <div
+                key={label}
+                className="rounded-2xl bg-white/5 border border-white/10 backdrop-blur-sm px-2 py-3 sm:px-4 sm:py-4 text-center"
+              >
+                <div className="font-display text-xl sm:text-3xl font-bold text-white tabular-nums">
+                  {value}
+                  {unit && <span className="ml-0.5 text-xs sm:text-sm font-semibold text-slate-400">{unit}</span>}
+                </div>
+                <div className="mt-1 text-[9px] sm:text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  {label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Phase timeline */}
+          <div className="mt-6">
+            <div className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+              Plan Structure
+            </div>
+            <div className="flex h-3 rounded-full overflow-hidden">
+              {segments.map((seg, i) => (
+                <div
+                  key={`${seg.phase}-${seg.startWeek}`}
+                  style={{
+                    flexGrow: seg.count,
+                    backgroundColor: PHASE_META[seg.phase].bg,
+                  }}
+                  title={`${seg.phase}: weeks ${seg.startWeek}–${seg.endWeek}`}
+                  className={cn(
+                    "h-full transition-all hover:brightness-110",
+                    i > 0 && "border-l border-slate-900/40"
+                  )}
+                />
+              ))}
+            </div>
+
+            {/* inline labels — sm and up */}
+            <div className="hidden sm:flex mt-2 gap-1">
+              {segments.map((seg) => (
+                <div
+                  key={`lbl-${seg.phase}-${seg.startWeek}`}
+                  style={{ flexGrow: seg.count }}
+                  className="min-w-0"
+                >
+                  {seg.count >= 2 && (
+                    <>
+                      <div className="truncate text-xs font-bold text-white">
+                        {seg.phase}
+                      </div>
+                      <div className="text-[10px] font-mono text-slate-400">
+                        Wk {seg.startWeek}–{seg.endWeek}
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {/* compact legend — mobile only, never clips */}
+            <div className="flex sm:hidden flex-wrap gap-x-4 gap-y-1.5 mt-3">
+              {segments.map((seg) => (
+                <div
+                  key={`legend-${seg.phase}-${seg.startWeek}`}
+                  className="flex items-center gap-1.5 text-xs text-slate-300"
+                >
+                  <span
+                    className="h-2 w-2 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: PHASE_META[seg.phase].bg }}
+                  />
+                  {seg.phase}
+                  <span className="text-slate-500">({seg.count}w)</span>
+                </div>
+              ))}
             </div>
           </div>
-        ))}
+        </div>
       </div>
 
-      {/* Phase timeline */}
-      <div>
+      {/* ── Weekly volume ────────────────────────────────────────────── */}
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-5 sm:p-6">
+        <VolumeChart weeks={plan.weeks} />
+      </div>
+
+      {/* ── Pace zones ───────────────────────────────────────────────── */}
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-5 sm:p-6">
         <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-3">
-          Plan Structure
+          Training Paces
         </div>
-        <div className="flex rounded-xl overflow-hidden border border-slate-200 h-10">
-          {(Object.entries(phaseSummary) as [TrainingPhase, number][]).map(
-            ([phase, count]) => (
+        <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+          {PACE_ZONE_ORDER.map(({ key, label, bg, text }) => (
+            <div
+              key={key}
+              className="rounded-xl overflow-hidden border border-slate-100 flex"
+            >
+              <div className="w-1.5 flex-shrink-0" style={{ backgroundColor: bg }} />
               <div
-                key={phase}
-                style={{
-                  width: `${(count / plan.totalWeeks) * 100}%`,
-                  backgroundColor: phaseColor(phase),
-                }}
-                title={`${phase}: ${count} weeks`}
-                className="flex items-center justify-center text-xs font-bold text-slate-700 overflow-hidden"
+                className="flex-1 px-2.5 py-2.5 sm:px-3 sm:py-3 text-center"
+                style={{ backgroundColor: `${bg}1a` }}
               >
-                {count >= 2 ? phase.split(" ")[0] : ""}
-              </div>
-            )
-          )}
-        </div>
-        <div className="flex flex-wrap gap-3 mt-3">
-          {(Object.entries(phaseSummary) as [TrainingPhase, number][]).map(
-            ([phase, count]) => (
-              <div key={phase} className="flex items-center gap-2">
                 <div
-                  className="w-3 h-3 rounded-sm"
-                  style={{ backgroundColor: phaseColor(phase) }}
-                />
-                <span className="text-xs text-slate-600">
-                  {phase} ({count}w)
-                </span>
+                  className="text-sm sm:text-base font-bold font-mono tabular-nums"
+                  style={{ color: text }}
+                >
+                  {plan.paces[key]}
+                  <span className="ml-0.5 text-[10px] font-semibold text-slate-400">
+                    /km
+                  </span>
+                </div>
+                <div className="mt-0.5 text-[10px] sm:text-xs font-semibold text-slate-500 uppercase tracking-wide">
+                  {label}
+                </div>
               </div>
-            )
-          )}
-        </div>
-      </div>
-
-      {/* Volume ramp chart */}
-      <VolumeChart weeks={plan.weeks} />
-
-      {/* Paces */}
-      <div>
-        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-3">
-          Training Paces (min/km)
-        </div>
-        <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
-          {(
-            [
-              ["Easy", plan.paces.easy],
-              ["Long", plan.paces.long],
-              ["Tempo", plan.paces.tempo],
-              ["Interval", plan.paces.interval],
-              ["Recovery", plan.paces.recovery],
-            ] as [string, string][]
-          ).map(([label, pace]) => (
-            <div key={label} className="bg-emerald-50 border border-emerald-100 rounded-xl p-3 text-center">
-              <div className="text-base font-bold text-emerald-700 font-mono">{pace}</div>
-              <div className="text-xs text-slate-500 mt-0.5">{label}</div>
             </div>
           ))}
         </div>

--- a/vite-project/src/features/plan/components/PlanStats.tsx
+++ b/vite-project/src/features/plan/components/PlanStats.tsx
@@ -1,0 +1,166 @@
+import type { TrainingPlan, TrainingWeek } from "../types";
+import { PHASE_META, PACE_ZONE_ORDER, phaseSegments } from "../utils/planDisplay";
+import { cn } from "@/lib/utils";
+
+function VolumeChart({ weeks }: { weeks: TrainingWeek[] }) {
+  const maxKm = Math.max(...weeks.map((w) => w.totalKm), 1);
+  const peakIdx = weeks.reduce((best, w, i) => (w.totalKm > weeks[best].totalKm ? i : best), 0);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-3">
+        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
+          Weekly Volume
+        </div>
+        <div className="text-xs text-slate-400">{weeks.length} weeks</div>
+      </div>
+      <div className="relative h-28 sm:h-32 pt-5">
+        <div
+          className="absolute top-0 text-[9px] font-bold uppercase tracking-wide text-emerald-600 whitespace-nowrap"
+          style={{ left: `${((peakIdx + 0.5) / weeks.length) * 100}%`, transform: "translateX(-50%)" }}
+        >
+          Peak
+        </div>
+        <div className="absolute inset-x-0 bottom-0 top-5 flex items-end gap-[3px]">
+          {weeks.map((w, i) => {
+            const pct = Math.max((w.totalKm / maxKm) * 100, 4);
+            const meta = PHASE_META[w.phase];
+            const isPeak = i === peakIdx;
+            return (
+              <div key={w.weekNumber} className="relative flex-1 min-w-0 h-full">
+                <div
+                  className={cn(
+                    "absolute bottom-0 inset-x-0 rounded-t-sm transition-all",
+                    isPeak && "ring-2 ring-emerald-400"
+                  )}
+                  style={{ height: `${pct}%`, backgroundColor: meta.bg }}
+                  title={`Week ${w.weekNumber} · ${w.totalKm} km · ${w.phase}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="flex justify-between mt-2 text-[10px] font-mono text-slate-400">
+        <span>Wk 1</span>
+        <span>Wk {weeks.length}</span>
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  plan: TrainingPlan;
+}
+
+/**
+ * Stats segment — everything that was pulled out of the lean hero (see
+ * PlanOverview.tsx): weekly volume chart, training pace zone cards, and the
+ * full phase timeline (inline labels on sm+, compact legend on mobile).
+ */
+export function PlanStats({ plan }: Props) {
+  const segments = phaseSegments(plan.weeks);
+
+  return (
+    <div className="space-y-4">
+      {/* ── Phase timeline (full) ────────────────────────────────────── */}
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-5 sm:p-6">
+        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-3">
+          Plan Structure
+        </div>
+        <div className="flex h-3 rounded-full overflow-hidden">
+          {segments.map((seg, i) => (
+            <div
+              key={`${seg.phase}-${seg.startWeek}`}
+              style={{
+                flexGrow: seg.count,
+                backgroundColor: PHASE_META[seg.phase].bg,
+              }}
+              title={`${seg.phase}: weeks ${seg.startWeek}–${seg.endWeek}`}
+              className={cn(
+                "h-full transition-all hover:brightness-110",
+                i > 0 && "border-l border-slate-900/20"
+              )}
+            />
+          ))}
+        </div>
+
+        {/* inline labels — sm and up */}
+        <div className="hidden sm:flex mt-2 gap-1">
+          {segments.map((seg) => (
+            <div
+              key={`lbl-${seg.phase}-${seg.startWeek}`}
+              style={{ flexGrow: seg.count }}
+              className="min-w-0"
+            >
+              {seg.count >= 2 && (
+                <>
+                  <div className="truncate text-xs font-bold text-slate-800">{seg.phase}</div>
+                  <div className="text-[10px] font-mono text-slate-400">
+                    Wk {seg.startWeek}–{seg.endWeek}
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* compact legend — mobile only, never clips */}
+        <div className="flex sm:hidden flex-wrap gap-x-4 gap-y-1.5 mt-3">
+          {segments.map((seg) => (
+            <div
+              key={`legend-${seg.phase}-${seg.startWeek}`}
+              className="flex items-center gap-1.5 text-xs text-slate-600"
+            >
+              <span
+                className="h-2 w-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: PHASE_META[seg.phase].bg }}
+              />
+              {seg.phase}
+              <span className="text-slate-400">({seg.count}w)</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Weekly volume ────────────────────────────────────────────── */}
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-5 sm:p-6">
+        <VolumeChart weeks={plan.weeks} />
+      </div>
+
+      {/* ── Pace zones ───────────────────────────────────────────────── */}
+      <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-5 sm:p-6">
+        <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-3">
+          Training Paces
+        </div>
+        <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+          {PACE_ZONE_ORDER.map(({ key, label, bg, text }) => (
+            <div
+              key={key}
+              className="rounded-xl overflow-hidden border border-slate-100 flex"
+            >
+              <div className="w-1.5 flex-shrink-0" style={{ backgroundColor: bg }} />
+              <div
+                className="flex-1 px-2.5 py-2.5 sm:px-3 sm:py-3 text-center"
+                style={{ backgroundColor: `${bg}1a` }}
+              >
+                <div
+                  className="text-sm sm:text-base font-bold font-mono tabular-nums"
+                  style={{ color: text }}
+                >
+                  {plan.paces[key]}
+                  <span className="ml-0.5 text-[10px] font-semibold text-slate-400">
+                    /km
+                  </span>
+                </div>
+                <div className="mt-0.5 text-[10px] sm:text-xs font-semibold text-slate-500 uppercase tracking-wide">
+                  {label}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/vite-project/src/features/plan/components/ThisWeekCard.tsx
+++ b/vite-project/src/features/plan/components/ThisWeekCard.tsx
@@ -1,0 +1,240 @@
+/**
+ * Training Plan — "This Week" summary card
+ *
+ * A sibling of the PlanOverview hero: surfaces the current training week at
+ * a glance — phase, the next run coming up (with a real calendar date), and
+ * the rest of this week's runs with their done state. Presentational only —
+ * takes plan + already-computed progress functions from usePlanProgress and
+ * renders based on them; it doesn't manage any state of its own (beyond the
+ * pure date math needed to tell "before plan starts" from "after race day").
+ */
+
+import type { RunDay, TrainingPlan, TrainingWeek } from "../types";
+import { WORKOUT_META, PHASE_META } from "../utils/planDisplay";
+import {
+  raceDateNoon,
+  todayNoon,
+  weekStartMonday,
+  type ScheduledWorkout,
+} from "../utils/planSchedule";
+import type { ProgressSummary } from "../hooks/usePlanProgress";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  plan: TrainingPlan;
+  currentWeekNumber: number | null;
+  nextWorkout: ScheduledWorkout | null;
+  planProgress: ProgressSummary;
+  weekProgress: (week: TrainingWeek) => ProgressSummary;
+  isComplete: (weekNumber: number, day: RunDay) => boolean;
+  onToggle: (weekNumber: number, day: RunDay) => void;
+  isPending?: (weekNumber: number, day: RunDay) => boolean;
+}
+
+function formatRealDate(date: Date): string {
+  return date.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+export function ThisWeekCard({
+  plan,
+  currentWeekNumber,
+  nextWorkout,
+  planProgress,
+  weekProgress,
+  isComplete,
+  onToggle,
+  isPending,
+}: Props) {
+  const today = todayNoon();
+  const week1Monday = weekStartMonday(plan.raceDate, 1, plan.totalWeeks);
+  const race = raceDateNoon(plan.raceDate);
+  const beforeStart = currentWeekNumber === null && today < week1Monday;
+  const afterRace = currentWeekNumber === null && !beforeStart && today > race;
+
+  if (afterRace) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-gradient-to-br from-emerald-50 to-white shadow-sm p-6 sm:p-8 text-center">
+        <div className="text-4xl mb-2" aria-hidden="true">
+          🎉
+        </div>
+        <h3 className="font-display text-xl font-bold text-slate-900">Plan complete!</h3>
+        <p className="mt-1 text-sm text-slate-600">
+          {plan.goalRace} — you crossed the finish line on your training.
+        </p>
+        {planProgress.totalCount > 0 && (
+          <div className="mt-4 inline-flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-1.5">
+            <span className="font-display text-sm font-bold text-emerald-700 tabular-nums">
+              {planProgress.completedCount}/{planProgress.totalCount} runs completed
+            </span>
+            <span className="text-xs font-semibold text-emerald-600">({planProgress.pct}%)</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const activeWeekNumber = currentWeekNumber ?? 1;
+  const week = plan.weeks.find((w) => w.weekNumber === activeWeekNumber);
+  if (!week) return null;
+
+  const wp = weekProgress(week);
+  const phaseMeta = PHASE_META[week.phase];
+
+  const daysUntilStart = beforeStart
+    ? Math.max(1, Math.round((week1Monday.getTime() - today.getTime()) / 86400000))
+    : null;
+
+  const highlighted = nextWorkout;
+  const highlightedMeta = highlighted ? WORKOUT_META[highlighted.workout.type] : null;
+
+  const restOfWeek = week.days.filter(
+    (d) =>
+      d.workout.type !== "rest" &&
+      !(highlighted && highlighted.weekNumber === week.weekNumber && highlighted.day === d.day)
+  );
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-5 sm:p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 flex-wrap mb-4">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className="text-[10px] sm:text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+            style={{ backgroundColor: phaseMeta.bg, color: phaseMeta.text }}
+          >
+            {phaseMeta.short}
+          </span>
+          <h3 className="font-display text-base sm:text-lg font-bold text-slate-900">
+            {beforeStart ? `Week 1 Preview` : `Week ${week.weekNumber} · This Week`}
+          </h3>
+        </div>
+        {beforeStart ? (
+          <span className="text-xs font-semibold text-slate-500">
+            Starts in {daysUntilStart} day{daysUntilStart === 1 ? "" : "s"}
+          </span>
+        ) : (
+          wp.totalCount > 0 && (
+            <span className="text-xs font-semibold text-slate-500 tabular-nums">
+              {wp.completedCount}/{wp.totalCount} runs · {wp.pct}%
+            </span>
+          )
+        )}
+      </div>
+
+      {!beforeStart && wp.totalCount > 0 && (
+        <div className="h-1.5 rounded-full bg-slate-100 overflow-hidden mb-5">
+          <div
+            className="h-full rounded-full bg-emerald-500 transition-all"
+            style={{ width: `${wp.pct}%` }}
+          />
+        </div>
+      )}
+
+      {/* Next run — highlighted */}
+      {highlighted && highlightedMeta && (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 mb-4">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <div className="flex items-center gap-3 min-w-0">
+              <span
+                className="flex-shrink-0 text-[11px] font-bold px-2.5 py-1 rounded-full whitespace-nowrap"
+                style={{ backgroundColor: highlightedMeta.bg, color: highlightedMeta.text }}
+              >
+                {highlighted.workout.label}
+              </span>
+              <div className="min-w-0">
+                <div className="flex items-baseline gap-1.5 font-display tabular-nums">
+                  {highlighted.workout.distanceKm !== undefined && highlighted.workout.distanceKm > 0 && (
+                    <span className="text-base font-bold text-slate-900">
+                      {highlighted.workout.distanceKm} km
+                    </span>
+                  )}
+                  {highlighted.workout.paceZone && (
+                    <span className="text-xs font-semibold text-emerald-700">
+                      @ {highlighted.workout.paceZone} pace
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-slate-500 mt-0.5">
+                  Next up · {formatRealDate(highlighted.date)}
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => onToggle(highlighted.weekNumber, highlighted.day)}
+              disabled={isPending?.(highlighted.weekNumber, highlighted.day)}
+              aria-pressed={isComplete(highlighted.weekNumber, highlighted.day)}
+              aria-label={`Mark ${highlighted.day} ${highlighted.workout.label} as done`}
+              className={cn(
+                "flex-shrink-0 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold px-4 py-2 text-sm transition-colors shadow-sm",
+                isPending?.(highlighted.weekNumber, highlighted.day) && "opacity-50 cursor-wait"
+              )}
+            >
+              Mark done
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Rest of the week */}
+      {restOfWeek.length > 0 && (
+        <div className="space-y-1.5">
+          {restOfWeek.map(({ day, workout }) => {
+            const meta = WORKOUT_META[workout.type];
+            const done = isComplete(week.weekNumber, day);
+            const pendingToggle = isPending?.(week.weekNumber, day) ?? false;
+            return (
+              <div
+                key={day}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg px-2.5 py-2 transition-colors",
+                  done ? "bg-emerald-50/60" : "hover:bg-slate-50"
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => onToggle(week.weekNumber, day)}
+                  disabled={pendingToggle}
+                  aria-pressed={done}
+                  aria-label={`Mark ${day} ${workout.label} as ${done ? "not done" : "done"}`}
+                  className={cn(
+                    "flex-shrink-0 h-5 w-5 p-0 rounded-full border flex items-center justify-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500 focus-visible:outline-offset-1",
+                    done
+                      ? "bg-emerald-600 border-emerald-600 text-white"
+                      : "bg-white border-slate-300 text-transparent hover:border-emerald-400",
+                    pendingToggle && "opacity-50 cursor-wait"
+                  )}
+                >
+                  <svg
+                    className="h-3 w-3"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                </button>
+                <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400 w-8 flex-shrink-0">
+                  {day}
+                </span>
+                <span
+                  className="flex-shrink-0 text-[11px] font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+                  style={{ backgroundColor: meta.bg, color: meta.text }}
+                >
+                  {workout.label}
+                </span>
+                {workout.distanceKm !== undefined && workout.distanceKm > 0 && (
+                  <span className="text-xs font-semibold text-slate-500 tabular-nums ml-auto flex-shrink-0">
+                    {workout.distanceKm} km
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/vite-project/src/features/plan/components/ThisWeekCard.tsx
+++ b/vite-project/src/features/plan/components/ThisWeekCard.tsx
@@ -94,9 +94,9 @@ export function ThisWeekCard({
   );
 
   return (
-    <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-5 sm:p-6">
+    <div className="rounded-2xl border border-slate-200 bg-white shadow-sm p-4 sm:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between gap-3 flex-wrap mb-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap mb-3 sm:mb-4">
         <div className="flex items-center gap-2 flex-wrap">
           <span
             className="text-[10px] sm:text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
@@ -122,7 +122,7 @@ export function ThisWeekCard({
       </div>
 
       {!beforeStart && wp.totalCount > 0 && (
-        <div className="h-1.5 rounded-full bg-slate-100 overflow-hidden mb-5">
+        <div className="h-1.5 rounded-full bg-slate-100 overflow-hidden mb-3 sm:mb-5">
           <div
             className="h-full rounded-full bg-emerald-500 transition-all"
             style={{ width: `${wp.pct}%` }}
@@ -132,7 +132,7 @@ export function ThisWeekCard({
 
       {/* Next run — highlighted */}
       {highlighted && highlightedMeta && (
-        <div className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 mb-4">
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-3 sm:p-4 mb-3 sm:mb-4">
           <div className="flex items-center justify-between gap-3 flex-wrap">
             <div className="flex items-center gap-3 min-w-0">
               <span
@@ -187,7 +187,7 @@ export function ThisWeekCard({
               <div
                 key={day}
                 className={cn(
-                  "flex items-center gap-3 rounded-lg px-2.5 py-2 transition-colors",
+                  "flex items-center gap-3 rounded-lg px-2.5 py-1.5 sm:py-2 transition-colors",
                   done ? "bg-emerald-50/60" : "hover:bg-slate-50"
                 )}
               >

--- a/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
+++ b/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
@@ -2,15 +2,18 @@ import { useEffect, useMemo, useRef } from "react";
 import { useAuth } from "../../auth/AuthContext";
 import { usePlanGenerator } from "../hooks/usePlanGenerator";
 import { useSavePlan } from "../hooks/useSavePlan";
+import { usePlanProgress } from "../hooks/usePlanProgress";
 import { PlanInputForm } from "./PlanInputForm";
 import { PlanOverview } from "./PlanOverview";
 import { PlanCalendar } from "./PlanCalendar";
+import { ThisWeekCard } from "./ThisWeekCard";
 import {
   loadDraftInputs,
   clearDraftPlan,
   getPendingSave,
   setPendingSave,
   clearPendingSave,
+  clearGuestProgress,
 } from "../utils/planPersistence";
 
 import type { GoalRace } from "../types";
@@ -31,6 +34,11 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
   const { user, loading: authLoading } = useAuth();
   const { plan, error, generate, reset } = usePlanGenerator();
   const { save, saving, savedId, error: saveError } = useSavePlan();
+  // Before save, planId is undefined and progress lives in guest localStorage
+  // (even for signed-in users viewing an unsaved plan) — those ticks ride
+  // into the Firestore doc via useSavePlan's readGuestProgress() merge once
+  // savedId lands and this hook starts writing there instead.
+  const progress = usePlanProgress({ plan, planId: savedId ?? undefined, userId: user?.uid });
 
   // Previously-entered form values restored from localStorage (see planPersistence.ts).
   // Loaded once — regenerating requires "Start over" first, which remounts the form.
@@ -59,6 +67,7 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
     if (savedId) {
       clearDraftPlan();
       clearPendingSave();
+      clearGuestProgress();
     }
   }, [savedId]);
 
@@ -111,7 +120,18 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
             Start over
           </button>
 
-          <PlanOverview plan={plan} />
+          <PlanOverview plan={plan} progress={progress.planProgress} />
+
+          <ThisWeekCard
+            plan={plan}
+            currentWeekNumber={progress.currentWeekNumber}
+            nextWorkout={progress.nextWorkout}
+            planProgress={progress.planProgress}
+            weekProgress={progress.weekProgress}
+            isComplete={progress.isComplete}
+            onToggle={progress.toggle}
+            isPending={progress.isPending}
+          />
 
           {/* Save prompt for logged-in users */}
           {!user && (
@@ -138,11 +158,18 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
             </div>
           )}
 
+          {progress.error && (
+            <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {progress.error}
+            </div>
+          )}
+
           <PlanCalendar
             plan={plan}
             onSave={user ? handleSave : undefined}
             saving={saving}
             savedId={savedId}
+            progress={progress}
           />
         </div>
       )}

--- a/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
+++ b/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
@@ -1,9 +1,17 @@
+import { useEffect, useMemo, useRef } from "react";
 import { useAuth } from "../../auth/AuthContext";
 import { usePlanGenerator } from "../hooks/usePlanGenerator";
 import { useSavePlan } from "../hooks/useSavePlan";
 import { PlanInputForm } from "./PlanInputForm";
 import { PlanOverview } from "./PlanOverview";
 import { PlanCalendar } from "./PlanCalendar";
+import {
+  loadDraftInputs,
+  clearDraftPlan,
+  getPendingSave,
+  setPendingSave,
+  clearPendingSave,
+} from "../utils/planPersistence";
 
 import type { GoalRace } from "../types";
 
@@ -20,14 +28,39 @@ interface Props {
 }
 
 export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSource, prefillGoal }: Props) {
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const { plan, error, generate, reset } = usePlanGenerator();
   const { save, saving, savedId, error: saveError } = useSavePlan();
+
+  // Previously-entered form values restored from localStorage (see planPersistence.ts).
+  // Loaded once — regenerating requires "Start over" first, which remounts the form.
+  const draftInputs = useMemo(() => loadDraftInputs(), []);
 
   async function handleSave() {
     if (!plan || !user) return;
     await save(plan, user.uid);
   }
+
+  // Sign-in handoff: a guest clicked "Sign in" on a generated plan, flagging it for
+  // auto-save. If they return here signed in with the plan restored, save it for them
+  // instead of making them click "Save" again.
+  const autoSaveAttempted = useRef(false);
+  useEffect(() => {
+    if (authLoading || !user || !plan) return;
+    if (!getPendingSave()) return;
+    if (autoSaveAttempted.current) return;
+    autoSaveAttempted.current = true;
+    save(plan, user.uid);
+  }, [authLoading, user, plan, save]);
+
+  // Once a plan is saved (manually or via auto-save), it lives in the dashboard —
+  // drop the local draft and any pending sign-in flag.
+  useEffect(() => {
+    if (savedId) {
+      clearDraftPlan();
+      clearPendingSave();
+    }
+  }, [savedId]);
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-10 space-y-10">
@@ -56,10 +89,13 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
           )}
           <PlanInputForm
             onGenerate={generate}
-            prefillPaces={prefillPaces}
-            prefillGoalTime={prefillGoalTime ?? prefillGoal?.goalTime}
-            prefillGoalRace={prefillGoal?.goalRace}
+            prefillPaces={prefillPaces ?? draftInputs?.paceResults}
+            prefillGoalTime={prefillGoalTime ?? prefillGoal?.goalTime ?? draftInputs?.goalTime}
+            prefillGoalRace={prefillGoal?.goalRace ?? draftInputs?.goalRace}
             prefillSource={prefillSource}
+            prefillRaceDate={draftInputs?.raceDate}
+            prefillFitness={draftInputs?.currentFitness}
+            prefillDays={draftInputs?.availableDays}
           />
         </div>
       ) : (
@@ -87,7 +123,8 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
                 </div>
               </div>
               <a
-                href="/login"
+                href="/login?returnTo=/plan"
+                onClick={setPendingSave}
                 className="flex-shrink-0 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold px-5 py-2.5 text-sm transition-colors"
               >
                 Sign in →

--- a/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
+++ b/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
@@ -1,12 +1,15 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../auth/AuthContext";
 import { usePlanGenerator } from "../hooks/usePlanGenerator";
 import { useSavePlan } from "../hooks/useSavePlan";
 import { usePlanProgress } from "../hooks/usePlanProgress";
 import { PlanInputForm } from "./PlanInputForm";
 import { PlanOverview } from "./PlanOverview";
+import { PlanStats } from "./PlanStats";
 import { PlanCalendar } from "./PlanCalendar";
 import { ThisWeekCard } from "./ThisWeekCard";
+import { WeekCard } from "./WeekCard";
+import { cn } from "@/lib/utils";
 import {
   loadDraftInputs,
   clearDraftPlan,
@@ -17,6 +20,63 @@ import {
 } from "../utils/planPersistence";
 
 import type { GoalRace } from "../types";
+
+type Segment = "thisweek" | "schedule" | "stats";
+
+const SEGMENT_TABS: { id: Segment; label: string }[] = [
+  { id: "thisweek", label: "This Week" },
+  { id: "schedule", label: "Schedule" },
+  { id: "stats", label: "Stats" },
+];
+
+function SegmentTabs({ active, onChange }: { active: Segment; onChange: (s: Segment) => void }) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Plan view"
+      className="sticky top-[72px] z-30 -mx-4 px-4 py-2.5 bg-white/85 backdrop-blur-md border-b border-slate-100"
+    >
+      <div className="flex gap-1 rounded-full bg-slate-100 p-1">
+        {SEGMENT_TABS.map((tab) => {
+          const selected = active === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onClick={() => onChange(tab.id)}
+              className={cn(
+                "flex-1 rounded-full py-2 px-1 text-[13px] sm:text-sm font-semibold whitespace-nowrap transition-colors",
+                selected
+                  ? "bg-emerald-600 text-white shadow-sm"
+                  : "text-slate-500 hover:text-slate-700"
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ProgressStrip({ completed, total, pct }: { completed: number; total: number; pct: number }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white shadow-sm px-4 py-3 flex items-center gap-3">
+      <div className="flex-1 h-2 rounded-full bg-slate-100 overflow-hidden">
+        <div
+          className="h-full rounded-full bg-emerald-500 transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="flex-shrink-0 text-xs font-semibold text-slate-500 tabular-nums">
+        {completed}/{total} runs · {pct}%
+      </span>
+    </div>
+  );
+}
 
 interface Props {
   prefillPaces?: {
@@ -43,6 +103,40 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
   // Previously-entered form values restored from localStorage (see planPersistence.ts).
   // Loaded once — regenerating requires "Start over" first, which remounts the form.
   const draftInputs = useMemo(() => loadDraftInputs(), []);
+
+  // Segmented plan view — defaults to This Week once the plan is in progress
+  // (a current week exists), else Schedule (plan hasn't started, or it's
+  // over). `userSegment` is the rider's own tab choice, which always wins;
+  // it's cleared whenever `plan` changes identity (a fresh generate, or
+  // "Start over" clearing it) so the next plan gets its own fresh default.
+  // Adjusting state during render (rather than in an effect) so the segment
+  // is correct on the very same render the plan first appears — PlanCalendar
+  // stays mounted across tab switches (to track "have we auto-scrolled yet"
+  // and not lose accordion state), so if it briefly rendered as the active
+  // segment before a later effect corrected the default, its own
+  // scroll-current-week-into-view effect would fire and yank the page.
+  const [userSegment, setUserSegment] = useState<Segment | null>(null);
+  const [trackedPlan, setTrackedPlan] = useState<typeof plan>(null);
+  if (plan !== trackedPlan) {
+    setTrackedPlan(plan);
+    setUserSegment(null);
+  }
+  const activeSegment: Segment = userSegment ?? (progress.currentWeekNumber !== null ? "thisweek" : "schedule");
+
+  const currentWeek = plan?.weeks.find((w) => w.weekNumber === progress.currentWeekNumber) ?? null;
+
+  // Reserve space above the fixed header + sticky segment tabs so
+  // scrollIntoView (the "jump to now" behavior in the Schedule segment)
+  // never tucks a card's top edge underneath them. Scoped to this page only
+  // — cleared on unmount rather than set globally.
+  useEffect(() => {
+    if (!plan) return;
+    const prev = document.documentElement.style.scrollPaddingTop;
+    document.documentElement.style.scrollPaddingTop = "170px";
+    return () => {
+      document.documentElement.style.scrollPaddingTop = prev;
+    };
+  }, [plan]);
 
   async function handleSave() {
     if (!plan || !user) return;
@@ -73,20 +167,24 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-10 space-y-10">
-      {/* Hero */}
-      <div>
-        <div className="inline-flex items-center gap-2 bg-emerald-50 border border-emerald-100 rounded-full px-4 py-1.5 text-sm font-semibold text-emerald-700 mb-4">
-          <span className="w-2 h-2 rounded-full bg-emerald-500 inline-block" />
-          TrainPace
+      {/* Marketing intro — only shown pre-generation. Once a plan exists, the
+          lean PlanOverview hero carries the page's identity instead, so this
+          duplicate title/tagline block would just be dead scroll height. */}
+      {!plan && (
+        <div>
+          <div className="inline-flex items-center gap-2 bg-emerald-50 border border-emerald-100 rounded-full px-4 py-1.5 text-sm font-semibold text-emerald-700 mb-4">
+            <span className="w-2 h-2 rounded-full bg-emerald-500 inline-block" />
+            TrainPace
+          </div>
+          <h1 className="text-4xl font-bold text-slate-900 tracking-tight">
+            Training Plan Generator
+          </h1>
+          <p className="mt-3 text-lg text-slate-600">
+            Science-backed periodized training plans built around your race, fitness
+            level, and schedule. Powered by Jack Daniels' VDOT methodology.
+          </p>
         </div>
-        <h1 className="text-4xl font-bold text-slate-900 tracking-tight">
-          Training Plan Generator
-        </h1>
-        <p className="mt-3 text-lg text-slate-600">
-          Science-backed periodized training plans built around your race, fitness
-          level, and schedule. Powered by Jack Daniels' VDOT methodology.
-        </p>
-      </div>
+      )}
 
       {!plan ? (
         <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-8">
@@ -108,7 +206,7 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
           />
         </div>
       ) : (
-        <div className="space-y-6">
+        <div className="space-y-4 sm:space-y-6">
           {/* Back button */}
           <button
             onClick={reset}
@@ -120,32 +218,21 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
             Start over
           </button>
 
-          <PlanOverview plan={plan} progress={progress.planProgress} />
-
-          <ThisWeekCard
-            plan={plan}
-            currentWeekNumber={progress.currentWeekNumber}
-            nextWorkout={progress.nextWorkout}
-            planProgress={progress.planProgress}
-            weekProgress={progress.weekProgress}
-            isComplete={progress.isComplete}
-            onToggle={progress.toggle}
-            isPending={progress.isPending}
-          />
+          <PlanOverview plan={plan} />
 
           {/* Save prompt for logged-in users */}
           {!user && (
-            <div className="rounded-2xl bg-emerald-50 border border-emerald-100 p-5 flex items-center justify-between gap-4">
+            <div className="rounded-2xl bg-emerald-50 border border-emerald-100 p-4 sm:p-5 flex items-center justify-between gap-4">
               <div>
-                <div className="font-semibold text-emerald-800">Save your plan</div>
-                <div className="text-sm text-emerald-700 mt-0.5">
+                <div className="font-semibold text-emerald-800 text-sm sm:text-base">Save your plan</div>
+                <div className="hidden sm:block text-sm text-emerald-700 mt-0.5">
                   Sign in to save this plan to your dashboard and track your progress.
                 </div>
               </div>
               <a
                 href="/login?returnTo=/plan"
                 onClick={setPendingSave}
-                className="flex-shrink-0 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold px-5 py-2.5 text-sm transition-colors"
+                className="flex-shrink-0 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold px-4 sm:px-5 py-2 sm:py-2.5 text-sm transition-colors"
               >
                 Sign in →
               </a>
@@ -164,13 +251,60 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
             </div>
           )}
 
-          <PlanCalendar
-            plan={plan}
-            onSave={user ? handleSave : undefined}
-            saving={saving}
-            savedId={savedId}
-            progress={progress}
-          />
+          <SegmentTabs active={activeSegment} onChange={setUserSegment} />
+
+          {/* This Week */}
+          <div className={cn("space-y-3 sm:space-y-4", activeSegment !== "thisweek" && "hidden")}>
+            <ThisWeekCard
+              plan={plan}
+              currentWeekNumber={progress.currentWeekNumber}
+              nextWorkout={progress.nextWorkout}
+              planProgress={progress.planProgress}
+              weekProgress={progress.weekProgress}
+              isComplete={progress.isComplete}
+              onToggle={progress.toggle}
+              isPending={progress.isPending}
+            />
+
+            {progress.planProgress.totalCount > 0 && (
+              <ProgressStrip
+                completed={progress.planProgress.completedCount}
+                total={progress.planProgress.totalCount}
+                pct={progress.planProgress.pct}
+              />
+            )}
+
+            {progress.currentWeekNumber !== null && currentWeek && (
+              <WeekCard
+                week={currentWeek}
+                isCurrent
+                defaultOpen
+                idSuffix="-thisweek"
+                progress={{
+                  isComplete: (day) => progress.isComplete(currentWeek.weekNumber, day),
+                  onToggle: (day) => progress.toggle(currentWeek.weekNumber, day),
+                  pending: (day) => progress.isPending(currentWeek.weekNumber, day),
+                }}
+              />
+            )}
+          </div>
+
+          {/* Schedule */}
+          <div className={cn(activeSegment !== "schedule" && "hidden")}>
+            <PlanCalendar
+              plan={plan}
+              onSave={user ? handleSave : undefined}
+              saving={saving}
+              savedId={savedId}
+              progress={progress}
+              isActive={activeSegment === "schedule"}
+            />
+          </div>
+
+          {/* Stats */}
+          <div className={cn(activeSegment !== "stats" && "hidden")}>
+            <PlanStats plan={plan} />
+          </div>
         </div>
       )}
     </div>

--- a/vite-project/src/features/plan/components/WeekCard.tsx
+++ b/vite-project/src/features/plan/components/WeekCard.tsx
@@ -1,118 +1,151 @@
 import { useState } from "react";
 import type { TrainingWeek } from "../types";
-import { workoutColor, workoutTextColor, phaseColor } from "../plan-math";
+import { WORKOUT_META, PHASE_META } from "../utils/planDisplay";
+import { cn } from "@/lib/utils";
 
 interface Props {
   week: TrainingWeek;
   isCurrent?: boolean;
+  /** Expanded on first render. Defaults to `isCurrent` when omitted. */
+  defaultOpen?: boolean;
 }
 
-export function WeekCard({ week, isCurrent = false }: Props) {
-  const [open, setOpen] = useState(isCurrent);
+export function WeekCard({ week, isCurrent = false, defaultOpen }: Props) {
+  const [open, setOpen] = useState(defaultOpen ?? isCurrent);
+  const phaseMeta = PHASE_META[week.phase];
+  const panelId = `week-panel-${week.weekNumber}`;
 
   return (
-    <div className={`bg-white rounded-2xl border shadow-sm overflow-hidden ${isCurrent ? "border-emerald-400 ring-2 ring-emerald-200" : "border-slate-200"}`}>
-      {/* Week header */}
-      <button
-        onClick={() => setOpen((o) => !o)}
-        className="w-full flex items-center gap-4 px-5 py-4 text-left hover:bg-slate-50 transition-colors"
-      >
-        {/* Week number */}
-        <div className="flex-shrink-0 w-12 h-12 rounded-xl bg-slate-100 flex items-center justify-center">
-          <span className="text-sm font-bold text-slate-700">W{week.weekNumber}</span>
-        </div>
-
-        {/* Phase + focus */}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-0.5 flex-wrap">
-            <span
-              className="text-xs font-bold px-2 py-0.5 rounded-full"
-              style={{
-                backgroundColor: phaseColor(week.phase),
-                color: week.phase === "Race Week" ? "#ffffff" : "#0f172a",
-              }}
-            >
-              {week.phase}
-            </span>
-            {isCurrent && (
-              <span className="text-xs font-bold px-2 py-0.5 rounded-full bg-emerald-600 text-white">
-                THIS WEEK
-              </span>
-            )}
-          </div>
-          <p className="text-sm text-slate-600 truncate">{week.weeklyFocus}</p>
-        </div>
-
-        {/* Volume */}
-        <div className="flex-shrink-0 text-right">
-          <div className="text-base font-bold text-emerald-600">{week.totalKm} km</div>
-          <div className="text-xs text-slate-400">{week.days.length} runs</div>
-        </div>
-
-        {/* Chevron */}
-        <svg
-          className={`flex-shrink-0 w-4 h-4 text-slate-400 transition-transform ${open ? "rotate-180" : ""}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-
-      {/* Expanded days */}
-      {open && (
-        <div className="border-t border-slate-100 px-5 py-4 space-y-3">
-          {/* Day strip */}
-          <div className="flex gap-2 flex-wrap">
-            {week.days.map(({ day, workout }) => (
-              <div
-                key={day}
-                className="flex flex-col items-center rounded-xl px-3 py-2 text-center min-w-[4rem]"
-                style={{
-                  backgroundColor: workoutColor(workout.type),
-                  color: workoutTextColor(workout.type),
-                }}
-              >
-                <span className="text-xs font-bold mb-1">{day}</span>
-                <span className="text-xs font-semibold leading-tight">{workout.label}</span>
-                {workout.distanceKm !== undefined && workout.distanceKm > 0 && (
-                  <span className="text-xs opacity-80 mt-0.5">{workout.distanceKm} km</span>
-                )}
-              </div>
-            ))}
-          </div>
-
-          {/* Workout details */}
-          <div className="space-y-2">
-            {week.days.map(({ day, workout }) => (
-              <div key={day} className="flex gap-3 items-start">
-                <span className="flex-shrink-0 w-9 text-xs font-bold text-slate-400 pt-0.5">
-                  {day}
-                </span>
-                <div>
-                  <span
-                    className="inline-block text-xs font-bold px-2 py-0.5 rounded-full mr-2"
-                    style={{
-                      backgroundColor: workoutColor(workout.type),
-                      color: workoutTextColor(workout.type),
-                    }}
-                  >
-                    {workout.label}
-                  </span>
-                  {workout.paceZone && (
-                    <span className="text-xs text-emerald-600 font-semibold mr-2">
-                      @ {workout.paceZone} pace
-                    </span>
-                  )}
-                  <span className="text-xs text-slate-600">{workout.description}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+    <div
+      className={cn(
+        "flex bg-white rounded-2xl border shadow-sm overflow-hidden",
+        isCurrent ? "border-emerald-400 ring-2 ring-emerald-200" : "border-slate-200"
       )}
+    >
+      {/* Phase-colored rail */}
+      <div className="w-1.5 flex-shrink-0" style={{ backgroundColor: phaseMeta.bg }} />
+
+      <div className="flex-1 min-w-0">
+        {/* Week header */}
+        <button
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          aria-controls={panelId}
+          className="w-full flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-4 text-left hover:bg-slate-50 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500 focus-visible:-outline-offset-2"
+        >
+          {/* Week number */}
+          <div className="flex-shrink-0 w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-slate-100 flex items-center justify-center">
+            <span className="font-display text-sm font-bold text-slate-700">
+              W{week.weekNumber}
+            </span>
+          </div>
+
+          {/* Phase + focus */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1 flex-wrap">
+              <span
+                className="text-[10px] sm:text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
+                style={{ backgroundColor: phaseMeta.bg, color: phaseMeta.text }}
+              >
+                {phaseMeta.short}
+              </span>
+              {isCurrent && (
+                <span className="text-[10px] sm:text-xs font-bold px-2 py-0.5 rounded-full bg-emerald-600 text-white whitespace-nowrap">
+                  THIS WEEK
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-slate-600 line-clamp-2 sm:line-clamp-1">
+              {week.weeklyFocus}
+            </p>
+          </div>
+
+          {/* Volume */}
+          <div className="flex-shrink-0 text-right">
+            <div className="font-display text-base font-bold text-emerald-600 tabular-nums">
+              {week.totalKm} km
+            </div>
+            <div className="text-xs text-slate-400">{week.days.length} runs</div>
+          </div>
+
+          {/* Chevron */}
+          <svg
+            className={cn(
+              "flex-shrink-0 w-4 h-4 text-slate-400 transition-transform",
+              open && "rotate-180"
+            )}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {/* Expanded days — rich day cards only, no duplicated list */}
+        {open && (
+          <div id={panelId} className="border-t border-slate-100 px-4 sm:px-5 py-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 sm:gap-3">
+              {week.days.map(({ day, workout }) => {
+                const meta = WORKOUT_META[workout.type];
+                const isRest = workout.type === "rest";
+                return (
+                  <div
+                    key={day}
+                    className={cn(
+                      "rounded-xl border border-slate-200 bg-white p-3 flex flex-col",
+                      isRest && "bg-slate-50 border-slate-100"
+                    )}
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
+                        {day}
+                      </span>
+                      <span
+                        className="h-2 w-2 rounded-full flex-shrink-0"
+                        style={{ backgroundColor: meta.bg }}
+                      />
+                    </div>
+
+                    <span
+                      className={cn(
+                        "self-start inline-block text-[11px] font-bold px-2 py-0.5 rounded-full mb-2",
+                        isRest && "opacity-80"
+                      )}
+                      style={{ backgroundColor: meta.bg, color: meta.text }}
+                    >
+                      {workout.label}
+                    </span>
+
+                    {!isRest && (
+                      <div className="flex items-baseline gap-1.5 mb-1 font-display tabular-nums">
+                        {workout.distanceKm !== undefined && workout.distanceKm > 0 && (
+                          <span className="text-sm font-bold text-slate-800">
+                            {workout.distanceKm} km
+                          </span>
+                        )}
+                        {workout.paceZone && (
+                          <span className="text-xs font-semibold text-emerald-600">
+                            @ {workout.paceZone} pace
+                          </span>
+                        )}
+                      </div>
+                    )}
+
+                    {!isRest && (
+                      <p className="text-xs text-slate-500 leading-snug mt-auto">
+                        {workout.description}
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/vite-project/src/features/plan/components/WeekCard.tsx
+++ b/vite-project/src/features/plan/components/WeekCard.tsx
@@ -16,12 +16,19 @@ interface Props {
   defaultOpen?: boolean;
   /** Omit for exact current read-only rendering (dashboard back-compat). */
   progress?: WeekCardProgress;
+  /**
+   * Disambiguates the panel id when the same week's WeekCard can be mounted
+   * more than once at a time (e.g. the plan page's This Week segment shows
+   * its own copy of the current week alongside PlanCalendar's, which stays
+   * mounted underneath the Schedule segment) — avoids duplicate DOM ids.
+   */
+  idSuffix?: string;
 }
 
-export function WeekCard({ week, isCurrent = false, defaultOpen, progress }: Props) {
+export function WeekCard({ week, isCurrent = false, defaultOpen, progress, idSuffix = "" }: Props) {
   const [open, setOpen] = useState(defaultOpen ?? isCurrent);
   const phaseMeta = PHASE_META[week.phase];
-  const panelId = `week-panel-${week.weekNumber}`;
+  const panelId = `week-panel-${week.weekNumber}${idSuffix}`;
 
   const trackableDays = week.days.filter((d) => d.workout.type !== "rest");
   const completedCount = progress
@@ -45,18 +52,18 @@ export function WeekCard({ week, isCurrent = false, defaultOpen, progress }: Pro
           onClick={() => setOpen((o) => !o)}
           aria-expanded={open}
           aria-controls={panelId}
-          className="w-full flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-4 text-left hover:bg-slate-50 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500 focus-visible:-outline-offset-2"
+          className="w-full flex items-center gap-2.5 sm:gap-4 px-3 sm:px-5 py-2 sm:py-4 text-left hover:bg-slate-50 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500 focus-visible:-outline-offset-2"
         >
           {/* Week number */}
-          <div className="flex-shrink-0 w-11 h-11 sm:w-12 sm:h-12 rounded-xl bg-slate-100 flex items-center justify-center">
-            <span className="font-display text-sm font-bold text-slate-700">
+          <div className="flex-shrink-0 w-8 h-8 sm:w-12 sm:h-12 rounded-lg sm:rounded-xl bg-slate-100 flex items-center justify-center">
+            <span className="font-display text-xs sm:text-sm font-bold text-slate-700">
               W{week.weekNumber}
             </span>
           </div>
 
           {/* Phase + focus */}
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <div className="flex items-center gap-2 mb-0.5 sm:mb-1 flex-wrap">
               <span
                 className="text-[10px] sm:text-xs font-bold px-2 py-0.5 rounded-full whitespace-nowrap"
                 style={{ backgroundColor: phaseMeta.bg, color: phaseMeta.text }}
@@ -69,29 +76,29 @@ export function WeekCard({ week, isCurrent = false, defaultOpen, progress }: Pro
                 </span>
               )}
             </div>
-            <p className="text-sm text-slate-600 line-clamp-2 sm:line-clamp-1">
+            <p className="text-xs sm:text-sm text-slate-600 line-clamp-1">
               {week.weeklyFocus}
             </p>
           </div>
 
           {/* Volume */}
           <div className="flex-shrink-0 text-right">
-            <div className="font-display text-base font-bold text-emerald-600 tabular-nums">
+            <div className="font-display text-sm sm:text-base font-bold text-emerald-600 tabular-nums">
               {week.totalKm} km
             </div>
             {progress ? (
-              <div className="text-xs font-semibold text-slate-500 tabular-nums">
+              <div className="text-[10px] sm:text-xs font-semibold text-slate-500 tabular-nums">
                 {completedCount}/{totalCount} runs
               </div>
             ) : (
-              <div className="text-xs text-slate-400">{week.days.length} runs</div>
+              <div className="text-[10px] sm:text-xs text-slate-400">{week.days.length} runs</div>
             )}
           </div>
 
           {/* Chevron */}
           <svg
             className={cn(
-              "flex-shrink-0 w-4 h-4 text-slate-400 transition-transform",
+              "flex-shrink-0 w-3.5 h-3.5 sm:w-4 sm:h-4 text-slate-400 transition-transform",
               open && "rotate-180"
             )}
             fill="none"
@@ -106,7 +113,7 @@ export function WeekCard({ week, isCurrent = false, defaultOpen, progress }: Pro
 
         {/* Thin progress bar — only when progress tracking is wired in */}
         {progress && totalCount > 0 && (
-          <div className="px-4 sm:px-5 -mt-1 pb-3">
+          <div className="px-3 sm:px-5 -mt-1 pb-2 sm:pb-3">
             <div className="h-1 rounded-full bg-slate-100 overflow-hidden">
               <div
                 className="h-full rounded-full bg-emerald-500 transition-all"
@@ -118,8 +125,8 @@ export function WeekCard({ week, isCurrent = false, defaultOpen, progress }: Pro
 
         {/* Expanded days — rich day cards only, no duplicated list */}
         {open && (
-          <div id={panelId} className="border-t border-slate-100 px-4 sm:px-5 py-4">
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 sm:gap-3">
+          <div id={panelId} className="border-t border-slate-100 px-3 sm:px-5 py-3 sm:py-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-1.5 sm:gap-3">
               {week.days.map(({ day, workout }) => {
                 const meta = WORKOUT_META[workout.type];
                 const isRest = workout.type === "rest";
@@ -129,12 +136,12 @@ export function WeekCard({ week, isCurrent = false, defaultOpen, progress }: Pro
                   <div
                     key={day}
                     className={cn(
-                      "rounded-xl border border-slate-200 bg-white p-3 flex flex-col",
+                      "rounded-xl border border-slate-200 bg-white p-2.5 sm:p-3 flex flex-col",
                       isRest && "bg-slate-50 border-slate-100",
                       done && "border-emerald-200 bg-emerald-50/40"
                     )}
                   >
-                    <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center justify-between mb-1.5 sm:mb-2">
                       <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
                         {day}
                       </span>

--- a/vite-project/src/features/plan/components/WeekCard.tsx
+++ b/vite-project/src/features/plan/components/WeekCard.tsx
@@ -1,19 +1,33 @@
 import { useState } from "react";
-import type { TrainingWeek } from "../types";
+import type { RunDay, TrainingWeek } from "../types";
 import { WORKOUT_META, PHASE_META } from "../utils/planDisplay";
 import { cn } from "@/lib/utils";
+
+export interface WeekCardProgress {
+  isComplete: (day: RunDay) => boolean;
+  onToggle: (day: RunDay) => void;
+  pending?: (day: RunDay) => boolean;
+}
 
 interface Props {
   week: TrainingWeek;
   isCurrent?: boolean;
   /** Expanded on first render. Defaults to `isCurrent` when omitted. */
   defaultOpen?: boolean;
+  /** Omit for exact current read-only rendering (dashboard back-compat). */
+  progress?: WeekCardProgress;
 }
 
-export function WeekCard({ week, isCurrent = false, defaultOpen }: Props) {
+export function WeekCard({ week, isCurrent = false, defaultOpen, progress }: Props) {
   const [open, setOpen] = useState(defaultOpen ?? isCurrent);
   const phaseMeta = PHASE_META[week.phase];
   const panelId = `week-panel-${week.weekNumber}`;
+
+  const trackableDays = week.days.filter((d) => d.workout.type !== "rest");
+  const completedCount = progress
+    ? trackableDays.filter((d) => progress.isComplete(d.day)).length
+    : 0;
+  const totalCount = trackableDays.length;
 
   return (
     <div
@@ -65,7 +79,13 @@ export function WeekCard({ week, isCurrent = false, defaultOpen }: Props) {
             <div className="font-display text-base font-bold text-emerald-600 tabular-nums">
               {week.totalKm} km
             </div>
-            <div className="text-xs text-slate-400">{week.days.length} runs</div>
+            {progress ? (
+              <div className="text-xs font-semibold text-slate-500 tabular-nums">
+                {completedCount}/{totalCount} runs
+              </div>
+            ) : (
+              <div className="text-xs text-slate-400">{week.days.length} runs</div>
+            )}
           </div>
 
           {/* Chevron */}
@@ -84,6 +104,18 @@ export function WeekCard({ week, isCurrent = false, defaultOpen }: Props) {
           </svg>
         </button>
 
+        {/* Thin progress bar — only when progress tracking is wired in */}
+        {progress && totalCount > 0 && (
+          <div className="px-4 sm:px-5 -mt-1 pb-3">
+            <div className="h-1 rounded-full bg-slate-100 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-emerald-500 transition-all"
+                style={{ width: `${(completedCount / totalCount) * 100}%` }}
+              />
+            </div>
+          </div>
+        )}
+
         {/* Expanded days — rich day cards only, no duplicated list */}
         {open && (
           <div id={panelId} className="border-t border-slate-100 px-4 sm:px-5 py-4">
@@ -91,22 +123,58 @@ export function WeekCard({ week, isCurrent = false, defaultOpen }: Props) {
               {week.days.map(({ day, workout }) => {
                 const meta = WORKOUT_META[workout.type];
                 const isRest = workout.type === "rest";
+                const done = !isRest && progress ? progress.isComplete(day) : false;
+                const pendingToggle = !isRest && progress?.pending ? progress.pending(day) : false;
                 return (
                   <div
                     key={day}
                     className={cn(
                       "rounded-xl border border-slate-200 bg-white p-3 flex flex-col",
-                      isRest && "bg-slate-50 border-slate-100"
+                      isRest && "bg-slate-50 border-slate-100",
+                      done && "border-emerald-200 bg-emerald-50/40"
                     )}
                   >
                     <div className="flex items-center justify-between mb-2">
                       <span className="text-[10px] font-bold uppercase tracking-wide text-slate-400">
                         {day}
                       </span>
-                      <span
-                        className="h-2 w-2 rounded-full flex-shrink-0"
-                        style={{ backgroundColor: meta.bg }}
-                      />
+                      <div className="flex items-center gap-2">
+                        {/* Workout-type dot is redundant with the toggle once progress
+                            tracking is wired in (the label pill below still carries color). */}
+                        {!(progress && !isRest) && (
+                          <span
+                            className="h-2 w-2 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: meta.bg }}
+                          />
+                        )}
+                        {!isRest && progress && (
+                          <button
+                            type="button"
+                            onClick={() => progress.onToggle(day)}
+                            disabled={pendingToggle}
+                            aria-pressed={done}
+                            aria-label={`Mark ${day} ${workout.label} as ${done ? "not done" : "done"}`}
+                            className={cn(
+                              "flex-shrink-0 h-5 w-5 p-0 rounded-full border-2 flex items-center justify-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500 focus-visible:outline-offset-1",
+                              done
+                                ? "bg-emerald-600 border-emerald-600 text-white"
+                                : "bg-white border-slate-300 text-transparent hover:border-emerald-400",
+                              pendingToggle && "opacity-50 cursor-wait"
+                            )}
+                          >
+                            <svg
+                              className="h-3 w-3"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              strokeWidth={3}
+                              aria-hidden="true"
+                            >
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                            </svg>
+                          </button>
+                        )}
+                      </div>
                     </div>
 
                     <span

--- a/vite-project/src/features/plan/hooks/usePlanGenerator.ts
+++ b/vite-project/src/features/plan/hooks/usePlanGenerator.ts
@@ -1,9 +1,16 @@
 import { useState, useCallback } from "react";
 import { generateTrainingPlan, weeksUntilRace } from "../plan-math";
 import type { PlanGeneratorInputs, TrainingPlan } from "../types";
+import {
+  loadDraftPlan,
+  saveDraftPlan,
+  clearDraftPlan,
+  saveDraftInputs,
+  clearPendingSave,
+} from "../utils/planPersistence";
 
 export function usePlanGenerator() {
-  const [plan, setPlan] = useState<TrainingPlan | null>(null);
+  const [plan, setPlan] = useState<TrainingPlan | null>(() => loadDraftPlan());
   const [error, setError] = useState<string | null>(null);
 
   const generate = useCallback((inputs: PlanGeneratorInputs) => {
@@ -28,6 +35,8 @@ export function usePlanGenerator() {
     try {
       const generated = generateTrainingPlan(inputs);
       setPlan(generated);
+      saveDraftPlan(generated);
+      saveDraftInputs(inputs);
     } catch (_e) {
       setError("Failed to generate plan. Please check your inputs.");
     }
@@ -36,6 +45,10 @@ export function usePlanGenerator() {
   const reset = useCallback(() => {
     setPlan(null);
     setError(null);
+    // Keep the persisted inputs so the form stays prefilled; only the
+    // generated plan (and any stale sign-in handoff) is discarded.
+    clearDraftPlan();
+    clearPendingSave();
   }, []);
 
   return { plan, error, generate, reset };

--- a/vite-project/src/features/plan/hooks/usePlanProgress.ts
+++ b/vite-project/src/features/plan/hooks/usePlanProgress.ts
@@ -1,0 +1,165 @@
+/**
+ * Training Plan — Workout Completion Tracking
+ *
+ * Owns the `completedWorkouts` map for a single plan (guest localStorage or
+ * a signed-in user's saved Firestore doc) and exposes read/toggle helpers
+ * that consumers (WeekCard, ThisWeekCard, PlanOverview, PlanCalendar) use to
+ * render and flip done-state. Consumes an already-loaded `plan` — never
+ * fetches its own copy.
+ *
+ * Guest mode: `planId` is undefined → toggles write straight to
+ * `trainpace_plan_progress` in localStorage.
+ * Signed-in + saved: `planId` is set → toggles optimistically flip local
+ * state, then persist via a dot-path Firestore update
+ * (`updateTrainingPlanProgress`), rolling back just that one key on failure.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import type { RunDay, TrainingPlan, TrainingWeek } from "../types";
+import {
+  currentWeekNumber as computeCurrentWeekNumber,
+  isTrackableWorkout,
+  nextWorkout as computeNextWorkout,
+  workoutKey,
+  type ScheduledWorkout,
+} from "../utils/planSchedule";
+import { readGuestProgress, writeGuestProgress } from "../utils/planPersistence";
+import { updateTrainingPlanProgress } from "../actions";
+
+export interface ProgressSummary {
+  completedCount: number;
+  totalCount: number;
+  pct: number;
+}
+
+interface UsePlanProgressArgs {
+  plan: TrainingPlan | null;
+  planId?: string;
+  userId?: string;
+}
+
+function summarize(days: { day: RunDay; trackable: boolean; done: boolean }[]): ProgressSummary {
+  const trackableDays = days.filter((d) => d.trackable);
+  const completedCount = trackableDays.filter((d) => d.done).length;
+  const totalCount = trackableDays.length;
+  return {
+    completedCount,
+    totalCount,
+    pct: totalCount ? Math.round((completedCount / totalCount) * 100) : 0,
+  };
+}
+
+export function usePlanProgress({ plan, planId }: UsePlanProgressArgs) {
+  const [completed, setCompleted] = useState<Record<string, string>>(() => {
+    if (planId) return plan?.completedWorkouts ?? {};
+    return readGuestProgress() ?? {};
+  });
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const isComplete = useCallback(
+    (weekNumber: number, day: RunDay) => Boolean(completed[workoutKey(weekNumber, day)]),
+    [completed]
+  );
+
+  const isPending = useCallback(
+    (weekNumber: number, day: RunDay) => Boolean(pending[workoutKey(weekNumber, day)]),
+    [pending]
+  );
+
+  const toggle = useCallback(
+    (weekNumber: number, day: RunDay) => {
+      if (!plan) return;
+      const week = plan.weeks.find((w) => w.weekNumber === weekNumber);
+      const trainingDay = week?.days.find((d) => d.day === day);
+      if (!trainingDay || !isTrackableWorkout(trainingDay.workout)) return;
+
+      const key = workoutKey(weekNumber, day);
+      const previousValue = completed[key];
+      const wasComplete = Boolean(previousValue);
+      const nextValue = wasComplete ? undefined : new Date().toISOString();
+
+      const nextMap = { ...completed };
+      if (nextValue) nextMap[key] = nextValue;
+      else delete nextMap[key];
+
+      setCompleted(nextMap);
+      setError(null);
+
+      if (planId) {
+        setPending((p) => ({ ...p, [key]: true }));
+        updateTrainingPlanProgress(planId, key, nextValue ?? null)
+          .catch(() => {
+            setCompleted((curr) => {
+              const rolledBack = { ...curr };
+              if (wasComplete) rolledBack[key] = previousValue;
+              else delete rolledBack[key];
+              return rolledBack;
+            });
+            setError("Couldn't save that — check your connection and try again.");
+          })
+          .finally(() => {
+            setPending((p) => {
+              const next = { ...p };
+              delete next[key];
+              return next;
+            });
+          });
+      } else {
+        try {
+          writeGuestProgress(nextMap);
+        } catch {
+          setError("Couldn't save progress locally.");
+        }
+      }
+    },
+    [plan, planId, completed]
+  );
+
+  const weekProgress = useCallback(
+    (week: TrainingWeek): ProgressSummary =>
+      summarize(
+        week.days.map(({ day, workout }) => ({
+          day,
+          trackable: isTrackableWorkout(workout),
+          done: Boolean(completed[workoutKey(week.weekNumber, day)]),
+        }))
+      ),
+    [completed]
+  );
+
+  const planProgress = useMemo<ProgressSummary>(() => {
+    if (!plan) return { completedCount: 0, totalCount: 0, pct: 0 };
+    const days = plan.weeks.flatMap((week) =>
+      week.days.map(({ day, workout }) => ({
+        day,
+        trackable: isTrackableWorkout(workout),
+        done: Boolean(completed[workoutKey(week.weekNumber, day)]),
+      }))
+    );
+    return summarize(days);
+  }, [plan, completed]);
+
+  const nextWorkoutValue = useMemo<ScheduledWorkout | null>(
+    () => (plan ? computeNextWorkout(plan, completed) : null),
+    [plan, completed]
+  );
+
+  const currentWeekNumberValue = useMemo<number | null>(
+    () => (plan ? computeCurrentWeekNumber(plan) : null),
+    [plan]
+  );
+
+  return {
+    isComplete,
+    toggle,
+    isPending,
+    weekProgress,
+    planProgress,
+    nextWorkout: nextWorkoutValue,
+    currentWeekNumber: currentWeekNumberValue,
+    error,
+  };
+}
+
+export type PlanProgress = ReturnType<typeof usePlanProgress>;

--- a/vite-project/src/features/plan/hooks/useSavePlan.ts
+++ b/vite-project/src/features/plan/hooks/useSavePlan.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "../../../lib/firebase";
 import type { TrainingPlan } from "../types";
+import { readGuestProgress, clearGuestProgress } from "../utils/planPersistence";
 
 export function useSavePlan() {
   const [saving, setSaving] = useState(false);
@@ -12,12 +13,18 @@ export function useSavePlan() {
     setSaving(true);
     setError(null);
     try {
+      // Carry over any guest-mode ticks (from before sign-in, or from a
+      // signed-in user viewing an unsaved plan) into the saved doc.
       const docRef = await addDoc(collection(db, "user_training_plans"), {
         ...plan,
         userId,
+        completedWorkouts: readGuestProgress() ?? {},
         createdAt: serverTimestamp(),
       });
       setSavedId(docRef.id);
+      // Safe to clear even though TrainingPlanGenerator also clears this
+      // once savedId lands — belt-and-suspenders for other save callers.
+      clearGuestProgress();
     } catch (_e) {
       setError("Failed to save plan. Please try again.");
     } finally {

--- a/vite-project/src/features/plan/index.ts
+++ b/vite-project/src/features/plan/index.ts
@@ -1,2 +1,7 @@
 export { TrainingPlanGenerator } from "./components/TrainingPlanGenerator";
+export { ThisWeekCard } from "./components/ThisWeekCard";
+export { usePlanProgress } from "./hooks/usePlanProgress";
+export type { PlanProgress, ProgressSummary } from "./hooks/usePlanProgress";
+export { selectActivePlan } from "./utils/planSchedule";
+export type { ScheduledWorkout } from "./utils/planSchedule";
 export type { TrainingPlan, PlanInputs, PlanGeneratorInputs, PlanPaces } from "./types";

--- a/vite-project/src/features/plan/types.ts
+++ b/vite-project/src/features/plan/types.ts
@@ -63,6 +63,17 @@ export interface TrainingPlan {
   weeks: TrainingWeek[];
   paces: PlanPaces;
   createdAt?: { seconds: number };
+  /**
+   * Workout completion tracking. Key = `${weekNumber}:${day}` (e.g. "3:Tue"),
+   * value = ISO completion timestamp. A Map-shape (not an array) so toggling
+   * is idempotent (set/delete a key) and dot-path partial Firestore updates
+   * let concurrent devices merge without clobbering each other. Bounded to
+   * roughly the plan's own (weekNumber, day) grid size (≤140 entries for the
+   * longest plans). Always iterate `plan.weeks` and look up keys here —
+   * never iterate this map directly, since regenerating a plan can leave
+   * orphaned keys behind that should be treated as inert.
+   */
+  completedWorkouts?: Record<string, string>;
 }
 
 export interface PlanPaces {

--- a/vite-project/src/features/plan/utils/exportIcal.ts
+++ b/vite-project/src/features/plan/utils/exportIcal.ts
@@ -7,16 +7,7 @@
  */
 
 import type { TrainingPlan, TrainingDay, TrainingWeek } from "../types";
-
-const DAY_OFFSET: Record<string, number> = {
-  Mon: 0,
-  Tue: 1,
-  Wed: 2,
-  Thu: 3,
-  Fri: 4,
-  Sat: 5,
-  Sun: 6,
-};
+import { DAY_OFFSET, mondayOffsetFromDayOfWeek } from "./planSchedule";
 
 function formatIcalDate(date: Date): string {
   const pad = (n: number) => String(n).padStart(2, "0");
@@ -39,13 +30,15 @@ function escapeIcal(str: string): string {
 }
 
 /**
- * Compute the Monday of the week that contains `raceDate`.
- * Week 1 starts (totalWeeks - 1) weeks before raceDate's week.
+ * Compute the Monday of the week that contains `raceDate`, in UTC (so the
+ * exported .ics timestamps don't drift with the exporting browser's
+ * timezone). Week 1 starts (totalWeeks - 1) weeks before raceDate's week.
+ * Reuses the shared Monday-offset formula from planSchedule.ts; only the
+ * UTC vs. local date arithmetic differs from planSchedule's own
+ * `weekStartMonday`.
  */
 function getWeekStartMonday(raceDate: Date, weekNumber: number, totalWeeks: number): Date {
-  // Find the Monday of the race week
-  const raceDay = raceDate.getUTCDay(); // 0=Sun, 1=Mon...
-  const daysToMonday = raceDay === 0 ? -6 : 1 - raceDay;
+  const daysToMonday = mondayOffsetFromDayOfWeek(raceDate.getUTCDay());
   const raceMondayMs = raceDate.getTime() + daysToMonday * 86400000;
 
   // Weeks are numbered 1..totalWeeks. Race week = totalWeeks.

--- a/vite-project/src/features/plan/utils/planDisplay.ts
+++ b/vite-project/src/features/plan/utils/planDisplay.ts
@@ -1,0 +1,95 @@
+/**
+ * Training Plan Generator — Display Constants
+ *
+ * Single source of truth for the color system used across the plan UI
+ * (hero overview, volume chart, phase legend, week list, day cards).
+ * Pure presentational helpers only — no plan-generation logic lives here.
+ * Kept separate from plan-math.ts, which owns the actual plan algorithm.
+ */
+
+import type { TrainingPhase, TrainingWeek, WorkoutType, PlanPaces } from "../types";
+
+interface WorkoutStyle {
+  /** Display name for the workout type */
+  name: string;
+  /** Saturated background — used for pills / dots / rails */
+  bg: string;
+  /** Text color for use on `bg` */
+  text: string;
+}
+
+// ── Workout type color system — one hue per type, used everywhere a
+//    workout shows up (day cards, pills, rails). ─────────────────────────
+export const WORKOUT_META: Record<WorkoutType, WorkoutStyle> = {
+  easy: { name: "Easy", bg: "#059669", text: "#ffffff" }, // emerald-600
+  long: { name: "Long", bg: "#0284c7", text: "#ffffff" }, // sky-600
+  tempo: { name: "Tempo", bg: "#d97706", text: "#ffffff" }, // amber-600
+  interval: { name: "Interval", bg: "#e11d48", text: "#ffffff" }, // rose-600
+  recovery: { name: "Recovery", bg: "#0d9488", text: "#ffffff" }, // teal-600
+  rest: { name: "Rest", bg: "#e2e8f0", text: "#64748b" }, // slate-200 / slate-500 (muted on purpose)
+  race: { name: "Race Day", bg: "#0f172a", text: "#ffffff" }, // slate-900 (ties to Race Week phase)
+};
+
+interface PhaseStyle {
+  /** Short label for tight spaces (mobile phase bar, chips) */
+  short: string;
+  /** Saturated background for bar segments / rails */
+  bg: string;
+  /** Text color for use on `bg` (badges) */
+  text: string;
+}
+
+// ── Phase color ramp — Base → Development → Sharpening → Taper → Race,
+//    so periodization progress reads at a glance. ────────────────────────
+export const PHASE_META: Record<TrainingPhase, PhaseStyle> = {
+  "Base Building": { short: "Base", bg: "#6ee7b7", text: "#064e3b" }, // emerald-300
+  Development: { short: "Development", bg: "#10b981", text: "#ffffff" }, // emerald-500
+  Sharpening: { short: "Sharpening", bg: "#047857", text: "#ffffff" }, // emerald-700
+  Taper: { short: "Taper", bg: "#94a3b8", text: "#0f172a" }, // slate-400 (muted — deliberately breaks the emerald ramp)
+  "Race Week": { short: "Race Week", bg: "#0f172a", text: "#ffffff" }, // slate-900
+};
+
+// ── Pace zone ramp — mirrors the pace-ladder landing shot: a single hue,
+//    lightness steps, easy end lightest, interval end darkest. The `text`
+//    color is calibrated for the zone card's own left-edge rail (`bg`),
+//    not for a tinted card background — see PlanOverview's pace cards. ──
+export const PACE_ZONE_ORDER: {
+  key: keyof PlanPaces;
+  label: string;
+  bg: string;
+  text: string;
+}[] = [
+  { key: "recovery", label: "Recovery", bg: "#a7f3d0", text: "#065f46" },
+  { key: "easy", label: "Easy", bg: "#6ee7b7", text: "#065f46" },
+  { key: "long", label: "Long", bg: "#34d399", text: "#022c22" },
+  { key: "tempo", label: "Tempo", bg: "#059669", text: "#022c22" },
+  { key: "interval", label: "Interval", bg: "#065f46", text: "#022c22" },
+];
+
+export interface PhaseSegment {
+  phase: TrainingPhase;
+  count: number;
+  startWeek: number;
+  endWeek: number;
+}
+
+/** Collapse a plan's weeks into contiguous phase runs (phases are always contiguous). */
+export function phaseSegments(weeks: TrainingWeek[]): PhaseSegment[] {
+  const segments: PhaseSegment[] = [];
+  for (const w of weeks) {
+    const last = segments[segments.length - 1];
+    if (last && last.phase === w.phase) {
+      last.count += 1;
+      last.endWeek = w.weekNumber;
+    } else {
+      segments.push({ phase: w.phase, count: 1, startWeek: w.weekNumber, endWeek: w.weekNumber });
+    }
+  }
+  return segments;
+}
+
+/** Extract a "Goal 1:45:00" style time from a generated plan name, if present. */
+export function parsePlanGoalTime(planName: string): string | null {
+  const m = planName.match(/Goal\s+([\d:]+)/i);
+  return m ? m[1] : null;
+}

--- a/vite-project/src/features/plan/utils/planPersistence.ts
+++ b/vite-project/src/features/plan/utils/planPersistence.ts
@@ -19,6 +19,7 @@ import type { PlanGeneratorInputs, TrainingPlan } from "../types";
 const DRAFT_PLAN_KEY = "trainpace_plan_draft";
 const DRAFT_INPUTS_KEY = "trainpace_plan_inputs";
 const PENDING_SAVE_KEY = "trainpace_plan_pending_save";
+const PROGRESS_KEY = "trainpace_plan_progress";
 
 function isRaceDateInPast(raceDate: unknown): boolean {
   if (typeof raceDate !== "string") return false;
@@ -125,6 +126,43 @@ export function setPendingSave(): void {
 export function clearPendingSave(): void {
   try {
     localStorage.removeItem(PENDING_SAVE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+function isCompletedWorkoutsMap(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every((v) => typeof v === "string");
+}
+
+/**
+ * Guest-mode workout completion tracking (mirrors `TrainingPlan.completedWorkouts`
+ * for signed-out users, and for signed-in users viewing an unsaved plan — see
+ * `useSavePlan`, which merges this into the Firestore doc on save).
+ */
+export function readGuestProgress(): Record<string, string> | null {
+  try {
+    const raw = localStorage.getItem(PROGRESS_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isCompletedWorkoutsMap(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeGuestProgress(progress: Record<string, string>): void {
+  try {
+    localStorage.setItem(PROGRESS_KEY, JSON.stringify(progress));
+  } catch {
+    // ignore
+  }
+}
+
+export function clearGuestProgress(): void {
+  try {
+    localStorage.removeItem(PROGRESS_KEY);
   } catch {
     // ignore
   }

--- a/vite-project/src/features/plan/utils/planPersistence.ts
+++ b/vite-project/src/features/plan/utils/planPersistence.ts
@@ -1,0 +1,131 @@
+/**
+ * Training Plan Generator — localStorage Persistence
+ *
+ * Guest users lose an in-memory plan on refresh. This module persists the
+ * generated plan, the form inputs used to generate it, and a "pending save"
+ * flag (set when a guest clicks the sign-in banner so we can auto-save once
+ * they return authenticated) to localStorage.
+ *
+ * Naming follows the existing convention in
+ * features/vdot-calculator/hooks/useVdotCalculator.ts (`trainpace_<feature>_<name>`).
+ *
+ * All reads/writes are wrapped in try/catch — localStorage can throw in
+ * private browsing / storage-disabled contexts, and this feature must not
+ * crash as a result.
+ */
+
+import type { PlanGeneratorInputs, TrainingPlan } from "../types";
+
+const DRAFT_PLAN_KEY = "trainpace_plan_draft";
+const DRAFT_INPUTS_KEY = "trainpace_plan_inputs";
+const PENDING_SAVE_KEY = "trainpace_plan_pending_save";
+
+function isRaceDateInPast(raceDate: unknown): boolean {
+  if (typeof raceDate !== "string") return false;
+  const ms = new Date(raceDate).getTime();
+  if (Number.isNaN(ms)) return false;
+  return ms < Date.now();
+}
+
+function isTrainingPlan(value: unknown): value is TrainingPlan {
+  if (!value || typeof value !== "object") return false;
+  const p = value as Partial<TrainingPlan>;
+  return Array.isArray(p.weeks) && typeof p.raceDate === "string";
+}
+
+function isPlanGeneratorInputs(value: unknown): value is PlanGeneratorInputs {
+  if (!value || typeof value !== "object") return false;
+  const p = value as Partial<PlanGeneratorInputs>;
+  return typeof p.raceDate === "string" && Array.isArray(p.availableDays);
+}
+
+/** Load the persisted draft plan, if any. Discards (and clears) stale drafts whose race date has passed. */
+export function loadDraftPlan(): TrainingPlan | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_PLAN_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isTrainingPlan(parsed)) return null;
+    if (isRaceDateInPast(parsed.raceDate)) {
+      clearDraftPlan();
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDraftPlan(plan: TrainingPlan): void {
+  try {
+    localStorage.setItem(DRAFT_PLAN_KEY, JSON.stringify(plan));
+  } catch {
+    // localStorage may be unavailable (e.g. private browsing) — ignore.
+  }
+}
+
+export function clearDraftPlan(): void {
+  try {
+    localStorage.removeItem(DRAFT_PLAN_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/** Load the persisted form inputs, if any. Discards inputs for a race date that has already passed. */
+export function loadDraftInputs(): PlanGeneratorInputs | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_INPUTS_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPlanGeneratorInputs(parsed)) return null;
+    if (isRaceDateInPast(parsed.raceDate)) {
+      clearDraftInputs();
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDraftInputs(inputs: PlanGeneratorInputs): void {
+  try {
+    localStorage.setItem(DRAFT_INPUTS_KEY, JSON.stringify(inputs));
+  } catch {
+    // ignore
+  }
+}
+
+export function clearDraftInputs(): void {
+  try {
+    localStorage.removeItem(DRAFT_INPUTS_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/** Whether a guest flagged this draft for auto-save after signing in. */
+export function getPendingSave(): boolean {
+  try {
+    return localStorage.getItem(PENDING_SAVE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setPendingSave(): void {
+  try {
+    localStorage.setItem(PENDING_SAVE_KEY, "1");
+  } catch {
+    // ignore
+  }
+}
+
+export function clearPendingSave(): void {
+  try {
+    localStorage.removeItem(PENDING_SAVE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/vite-project/src/features/plan/utils/planSchedule.ts
+++ b/vite-project/src/features/plan/utils/planSchedule.ts
@@ -1,0 +1,175 @@
+/**
+ * Training Plan — Calendar / Schedule Math
+ *
+ * Canonical date math for mapping a plan's abstract (weekNumber, day) grid
+ * onto real calendar dates. Race day is the last day of the final week;
+ * every other week's Monday is derived by walking backwards from there in
+ * whole 7-day steps. All arithmetic here operates in the browser's LOCAL
+ * timezone (via `Date` local getters/setters) so "today" and workout dates
+ * agree with what the user sees on their wall calendar.
+ *
+ * `exportIcal.ts` needs the same Monday-from-race-date formula but must stay
+ * in UTC (so exported .ics timestamps don't drift with the exporting
+ * browser's timezone) — it imports `DAY_OFFSET` and the shared
+ * `mondayOffsetFromDayOfWeek` helper from here rather than reimplementing
+ * the offset table / weekday math, but keeps its own UTC date arithmetic.
+ */
+
+import type { TrainingPlan, RunDay, Workout, TrainingDay } from "../types";
+
+export const DAY_OFFSET: Record<RunDay, number> = {
+  Mon: 0,
+  Tue: 1,
+  Wed: 2,
+  Thu: 3,
+  Fri: 4,
+  Sat: 5,
+  Sun: 6,
+};
+
+/**
+ * Given a JS day-of-week number (0=Sun..6=Sat), return the signed day
+ * offset that walks back to that week's Monday.
+ */
+export function mondayOffsetFromDayOfWeek(dayOfWeek: number): number {
+  return dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+}
+
+/** Parse an ISO date string ("YYYY-MM-DD") at LOCAL noon, to avoid DST/timezone drift. */
+function parseLocalNoon(dateStr: string): Date {
+  // If the string already carries a time component, respect it; otherwise pin to local noon.
+  const hasTime = /T\d{2}:\d{2}/.test(dateStr);
+  return new Date(hasTime ? dateStr : `${dateStr}T12:00:00`);
+}
+
+/** Add whole calendar days to a date via `setDate` (DST-safe for noon-anchored dates). */
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/** Local-noon `Date` for "today". */
+export function todayNoon(now: Date = new Date()): Date {
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12, 0, 0);
+}
+
+/** The race date itself, at local noon. */
+export function raceDateNoon(raceDate: string): Date {
+  return parseLocalNoon(raceDate);
+}
+
+/**
+ * Monday of the given week, in LOCAL time. Race day is the last day of the
+ * final week (`totalWeeks`); week 1's Monday is `(totalWeeks - 1) * 7` days
+ * before the race week's Monday.
+ */
+export function weekStartMonday(raceDate: string, weekNumber: number, totalWeeks: number): Date {
+  const race = parseLocalNoon(raceDate);
+  const daysToMonday = mondayOffsetFromDayOfWeek(race.getDay());
+  const raceMonday = addDays(race, daysToMonday);
+  const weeksBack = totalWeeks - weekNumber;
+  return addDays(raceMonday, -weeksBack * 7);
+}
+
+/** The local-noon calendar date for a specific (weekNumber, day) slot. */
+export function workoutDate(plan: TrainingPlan, weekNumber: number, day: RunDay): Date {
+  const monday = weekStartMonday(plan.raceDate, weekNumber, plan.totalWeeks);
+  return addDays(monday, DAY_OFFSET[day]);
+}
+
+/** Stable map key for a (weekNumber, day) slot — e.g. "3:Tue". */
+export function workoutKey(weekNumber: number, day: RunDay): string {
+  return `${weekNumber}:${day}`;
+}
+
+/** Rest days aren't trackable; every other workout type (including "race") is. */
+export function isTrackableWorkout(workout: Workout): boolean {
+  return workout.type !== "rest";
+}
+
+/**
+ * The week number whose [Monday, Monday+7d) span contains local-noon
+ * "today" — null if today is before the plan starts or after race day.
+ */
+export function currentWeekNumber(plan: TrainingPlan, now: Date = new Date()): number | null {
+  const today = todayNoon(now);
+  for (const week of plan.weeks) {
+    const monday = weekStartMonday(plan.raceDate, week.weekNumber, plan.totalWeeks);
+    const weekEnd = addDays(monday, 7);
+    if (today >= monday && today < weekEnd) {
+      return week.weekNumber;
+    }
+  }
+  return null;
+}
+
+export interface ScheduledWorkout {
+  weekNumber: number;
+  day: RunDay;
+  workout: Workout;
+  date: Date;
+}
+
+/**
+ * The earliest trackable, incomplete workout dated today-or-later; falls
+ * back to the chronologically-first incomplete workout overall (e.g. all
+ * remaining workouts are in the past); null if everything is complete.
+ */
+export function nextWorkout(
+  plan: TrainingPlan,
+  completed: Record<string, string> | undefined
+): ScheduledWorkout | null {
+  const today = todayNoon();
+  const scheduled: ScheduledWorkout[] = [];
+
+  for (const week of plan.weeks) {
+    for (const { day, workout } of week.days as TrainingDay[]) {
+      if (!isTrackableWorkout(workout)) continue;
+      const key = workoutKey(week.weekNumber, day);
+      if (completed?.[key]) continue;
+      scheduled.push({ weekNumber: week.weekNumber, day, workout, date: workoutDate(plan, week.weekNumber, day) });
+    }
+  }
+
+  scheduled.sort((a, b) => a.date.getTime() - b.date.getTime());
+  const upcoming = scheduled.find((s) => s.date.getTime() >= today.getTime());
+  return upcoming ?? scheduled[0] ?? null;
+}
+
+/**
+ * The plan a user is "currently in" — the one whose [week1 Monday, raceDate]
+ * span contains today (nearest raceDate wins ties), else the plan with the
+ * soonest upcoming raceDate, else null.
+ */
+export function selectActivePlan(plans: TrainingPlan[]): TrainingPlan | null {
+  const today = todayNoon();
+
+  let active: TrainingPlan | null = null;
+  let activeRaceMs = Infinity;
+  for (const plan of plans) {
+    if (!plan.raceDate || plan.weeks.length === 0) continue;
+    const week1Monday = weekStartMonday(plan.raceDate, 1, plan.totalWeeks);
+    const race = raceDateNoon(plan.raceDate);
+    if (today >= week1Monday && today <= race) {
+      const raceMs = race.getTime();
+      if (raceMs < activeRaceMs) {
+        active = plan;
+        activeRaceMs = raceMs;
+      }
+    }
+  }
+  if (active) return active;
+
+  let soonest: TrainingPlan | null = null;
+  let soonestMs = Infinity;
+  for (const plan of plans) {
+    if (!plan.raceDate) continue;
+    const raceMs = raceDateNoon(plan.raceDate).getTime();
+    if (raceMs >= today.getTime() && raceMs < soonestMs) {
+      soonest = plan;
+      soonestMs = raceMs;
+    }
+  }
+  return soonest;
+}

--- a/vite-project/src/pages/DashboardV2.tsx
+++ b/vite-project/src/pages/DashboardV2.tsx
@@ -329,8 +329,10 @@ export default function DashboardV2() {
       {activeTab === "training-plans" && (
         <TrainingPlansSection
           plans={filteredTrainingPlans}
+          allPlans={trainingPlans}
           loading={trainingPlansLoading}
           onDeletePlan={removeTrainingPlan}
+          userId={user?.uid}
         />
       )}
 


### PR DESCRIPTION
Turns the /plan generator from a one-shot form into a product users return to. Four stacked changes:

## 1. Runna-level visual redesign (`b60a2a4`)
- Dark emerald hero card: goal time as the dominant numeral, race-day countdown, big-number stat tiles, integrated phase timeline
- Single workout-type + phase color system (`utils/planDisplay.ts`) shared by the chart, badges, rails, and day cards
- Week list grouped by phase with colored rails; expanded weeks show rich day cards only (removed the duplicated text list)
- Pace chips became zone cards on the pace-ladder ramp; form got filled selected states and a CTA that explains itself

## 2. Draft persistence + sign-in handoff (`1ebfeff`)
- Generated plan + form inputs persist to localStorage (`trainpace_plan_draft` / `trainpace_plan_inputs`); restored on mount, stale drafts (past race date) self-clean, private-mode safe
- "Sign in to save" now links to `/login?returnTo=/plan` with a pending-save flag; on return the restored plan auto-saves once — previously the banner destroyed the plan the user was trying to save

## 3. Workout completion tracking (`5bdd63d`)
- `completedWorkouts` map on the plan doc (`"week:Day" → ISO timestamp`), toggled via dot-path updates so devices merge instead of clobbering; no Firestore rules change needed (owner update already allowed)
- Shared calendar math in `utils/planSchedule.ts`; PlanCalendar now agrees with the iCal export on week boundaries (fixes a latent current-week discrepancy)
- `usePlanProgress`: optimistic toggles with per-key rollback; guest progress lives in localStorage and merges into the doc at save time (including through the auto-save handoff)
- Done-toggles on day cards, n/m + progress bars on week rows / hero / dashboard cards, and a ThisWeekCard (next run up, real dates, before-start and post-race states) on /plan and the dashboard

## 4. Mobile de-scroll (`cbe3455`)
- Sticky This Week / Schedule / Stats segments; This Week is the default for in-progress plans
- Hero slimmed; volume chart + pace zones + phase details moved to Stats
- Compact week rows on mobile (82px → 55px); Schedule auto-scrolls to the current week once per visit (respects `prefers-reduced-motion`)
- Default mobile view: ~2561px tall vs ~5000px before (~49% reduction)

## Verification
- `npm run build` (tsc + full prerender) and `npm run lint` pass at every commit; no new warnings
- Playwright against the dev server: guest persistence flows (generate → reload → restored; start-over keeps inputs; stale/corrupt drafts handled), completion flows (tick → n/m + hero update → reload persists → un-tick decrements), segment behavior, and 390px layout checks (no clipped/orphaned/truncated text)
- Firebase-authenticated paths (auto-save, Firestore toggles) verified by code review + typecheck; worth a quick manual pass on a real login after deploy

Product defaults chosen (easy to flip): missed past runs render neutral (not red), future runs are tickable, race day is tickable as the capstone. The optional firestore.rules hardening (pinning `userId` on update) was deliberately left out — happy to follow up separately since rules deploys deserve their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gQkB7Td39HRHSY7Z7oL9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_011gQkB7Td39HRHSY7Z7oL9Z)_