### PR TITLE
feat: drag-and-drop workout rescheduling on a macOS-style plan calendar

### DIFF
--- a/vite-project/e2e/training-plan.spec.ts
+++ b/vite-project/e2e/training-plan.spec.ts
@@ -1,4 +1,38 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+/** Generate a guest Half Marathon plan ~6 weeks out (form → plan view). */
+async function generateHalfMarathonPlan(page: Page) {
+  await page.goto("/plan");
+  await page.waitForLoadState("networkidle");
+
+  await page.getByRole("button", { name: /Half Marathon/i }).first().click();
+
+  const raceDate = new Date();
+  raceDate.setDate(raceDate.getDate() + 42);
+  await page.locator('input[type="date"]').fill(raceDate.toISOString().split("T")[0]);
+
+  const generateBtn = page.getByRole("button", { name: /Generate My Plan/i });
+  await expect(generateBtn).toBeEnabled();
+  await generateBtn.click();
+  await expect(page.getByRole("button", { name: /Start over/i })).toBeVisible();
+}
+
+/**
+ * Drag a workout chip onto a target day cell with raw mouse events —
+ * dnd-kit's MouseSensor has a small distance activation constraint, so
+ * Playwright's dragTo (single synthetic move) may not trigger it.
+ */
+async function dragChip(page: Page, source: Locator, target: Locator) {
+  await source.scrollIntoViewIfNeeded();
+  const from = await source.boundingBox();
+  const to = await target.boundingBox();
+  if (!from || !to) throw new Error("drag source/target not visible");
+
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, { steps: 12 });
+  await page.mouse.up();
+}
 
 test.describe("Training Plan Generator", () => {
   test("should load the training plan page", async ({ page }) => {
@@ -42,6 +76,50 @@ test.describe("Training Plan Generator", () => {
     await expect(
       page.getByRole("button", { name: /Start over/i })
     ).toBeVisible();
+  });
+
+  test("should drag a workout to an empty day and persist the move", async ({ page }) => {
+    // Generate + drag + a second full navigation — needs more than the
+    // default 30s against the dev server's slow first loads.
+    test.setTimeout(90_000);
+    await generateHalfMarathonPlan(page);
+
+    // Default training days are Tue/Thu/Sat/Sun, so Wed is an empty cell.
+    const week1 = page.locator('[data-week="1"]');
+    const source = week1.locator('[data-day="Tue"] [data-chip]');
+    const target = week1.locator('[data-day="Wed"]');
+    await expect(source).toBeVisible();
+    const movedLabel = (await source.innerText()).split("\n")[0];
+
+    await dragChip(page, source, target);
+
+    // The workout now renders under Wed and Tue is empty.
+    await expect(week1.locator('[data-day="Wed"] [data-chip]')).toContainText(movedLabel);
+    await expect(week1.locator('[data-day="Tue"] [data-chip]')).toHaveCount(0);
+
+    // The move survives a fresh navigation via the localStorage draft.
+    // (goto instead of reload — reload's "load" event is flaky against the
+    // dev server; the assertions below auto-wait for the hydrated grid.)
+    await page.goto("/plan", { waitUntil: "domcontentloaded" });
+    await expect(week1.locator('[data-day="Wed"] [data-chip]')).toContainText(movedLabel);
+    await expect(week1.locator('[data-day="Tue"] [data-chip]')).toHaveCount(0);
+  });
+
+  test("should swap workouts when dropped on an occupied day", async ({ page }) => {
+    await generateHalfMarathonPlan(page);
+
+    const week1 = page.locator('[data-week="1"]');
+    const thuChip = week1.locator('[data-day="Thu"] [data-chip]');
+    const satChip = week1.locator('[data-day="Sat"] [data-chip]');
+    await expect(thuChip).toBeVisible();
+    await expect(satChip).toBeVisible();
+    const thuLabel = (await thuChip.innerText()).split("\n")[0];
+    const satLabel = (await satChip.innerText()).split("\n")[0];
+
+    await dragChip(page, thuChip, week1.locator('[data-day="Sat"]'));
+
+    await expect(week1.locator('[data-day="Sat"] [data-chip]')).toContainText(thuLabel);
+    await expect(week1.locator('[data-day="Thu"] [data-chip]')).toContainText(satLabel);
   });
 
   test("should accept URL params from pace calculator", async ({ page }) => {

--- a/vite-project/package-lock.json
+++ b/vite-project/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-project",
       "version": "2.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -1760,6 +1761,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/vite-project/package.json
+++ b/vite-project/package.json
@@ -17,6 +17,7 @@
     "test-gemini": "vite-node scripts/testGemini.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-dialog": "^1.1.2",

--- a/vite-project/src/features/plan/actions.ts
+++ b/vite-project/src/features/plan/actions.ts
@@ -3,8 +3,9 @@
  * to call from optimistic-update flows like usePlanProgress.toggle).
  */
 
-import { doc, updateDoc, deleteField } from "firebase/firestore";
+import { doc, updateDoc, deleteField, type FieldValue } from "firebase/firestore";
 import { db } from "../../lib/firebase";
+import type { TrainingWeek } from "./types";
 
 /**
  * Toggle a single workout's completion state via a dot-path partial update
@@ -21,4 +22,23 @@ export async function updateTrainingPlanProgress(
   await updateDoc(doc(db, "user_training_plans", planId), {
     [`completedWorkouts.${key}`]: value ?? deleteField(),
   });
+}
+
+/**
+ * Persist a schedule edit (workout moved/swapped to another day): rewrite the
+ * `weeks` array and migrate the affected completion keys in one atomic
+ * update. Firestore can't address array indices via field paths, so the
+ * whole (small, ≤20-entry) array is replaced; completion keys stay dot-path
+ * partial updates so other devices' concurrent toggles on other keys merge.
+ */
+export async function updateTrainingPlanSchedule(
+  planId: string,
+  weeks: TrainingWeek[],
+  completionDelta: Record<string, string | null>
+): Promise<void> {
+  const update: Record<string, TrainingWeek[] | string | FieldValue> = { weeks };
+  for (const [key, value] of Object.entries(completionDelta)) {
+    update[`completedWorkouts.${key}`] = value ?? deleteField();
+  }
+  await updateDoc(doc(db, "user_training_plans", planId), update);
 }

--- a/vite-project/src/features/plan/components/PlanCalendar.tsx
+++ b/vite-project/src/features/plan/components/PlanCalendar.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import type { TrainingPlan } from "../types";
-import { WeekCard } from "./WeekCard";
+import { PlanCalendarGrid } from "./PlanCalendarGrid";
 import type { PlanProgress } from "../hooks/usePlanProgress";
+import type { PlanEditor } from "../hooks/usePlanEditor";
 import { exportPlanAsIcal } from "../utils/exportIcal";
-import { phaseSegments, PHASE_META } from "../utils/planDisplay";
 import { currentWeekNumber } from "../utils/planSchedule";
 
 interface Props {
@@ -13,18 +13,19 @@ interface Props {
   savedId?: string | null;
   /** Omit for exact current read-only rendering (dashboard back-compat). */
   progress?: PlanProgress;
+  /** Omit for a read-only calendar; present = workouts drag-reschedule. */
+  editor?: PlanEditor;
   /**
    * Whether this calendar is the currently-visible segment. When it first
-   * turns true, the current week's card is scrolled into view — once per
+   * turns true, the current week's row is scrolled into view — once per
    * mount, not on every toggle back to this segment.
    */
   isActive?: boolean;
 }
 
-export function PlanCalendar({ plan, onSave, saving, savedId, progress, isActive }: Props) {
+export function PlanCalendar({ plan, onSave, saving, savedId, progress, editor, isActive }: Props) {
   const currentWeekNum = currentWeekNumber(plan);
   const [exported, setExported] = useState(false);
-  const segments = phaseSegments(plan.weeks);
   const currentWeekRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
 
@@ -88,49 +89,21 @@ export function PlanCalendar({ plan, onSave, saving, savedId, progress, isActive
         </div>
       )}
 
-      <div className="space-y-6">
-        {segments.map((seg) => (
-          <div key={`${seg.phase}-${seg.startWeek}`} className="space-y-3">
-            <div className="flex items-center gap-2 px-1">
-              <span
-                className="h-2.5 w-2.5 rounded-full flex-shrink-0"
-                style={{ backgroundColor: PHASE_META[seg.phase].bg }}
-              />
-              <h4 className="text-sm font-bold text-slate-800">{seg.phase}</h4>
-              <span className="text-xs font-mono text-slate-400">
-                {seg.startWeek === seg.endWeek
-                  ? `Week ${seg.startWeek}`
-                  : `Weeks ${seg.startWeek}–${seg.endWeek}`}
-              </span>
-            </div>
-            <div className="space-y-3">
-              {plan.weeks
-                .filter((w) => w.weekNumber >= seg.startWeek && w.weekNumber <= seg.endWeek)
-                .map((week) => (
-                  <div
-                    key={week.weekNumber}
-                    ref={week.weekNumber === currentWeekNum ? currentWeekRef : undefined}
-                  >
-                    <WeekCard
-                      week={week}
-                      isCurrent={week.weekNumber === currentWeekNum}
-                      defaultOpen={week.weekNumber === 1 || week.weekNumber === currentWeekNum}
-                      progress={
-                        progress
-                          ? {
-                              isComplete: (day) => progress.isComplete(week.weekNumber, day),
-                              onToggle: (day) => progress.toggle(week.weekNumber, day),
-                              pending: (day) => progress.isPending(week.weekNumber, day),
-                            }
-                          : undefined
-                      }
-                    />
-                  </div>
-                ))}
-            </div>
-          </div>
-        ))}
-      </div>
+      {editor && (
+        <p className="text-xs text-slate-400 px-1">
+          Life happens — drag a workout onto another day to reschedule it. Drop
+          on an occupied day to swap the two. On touch, press and hold to pick
+          one up.
+        </p>
+      )}
+
+      <PlanCalendarGrid
+        plan={plan}
+        currentWeekNum={currentWeekNum}
+        progress={progress}
+        editor={editor}
+        currentWeekRef={currentWeekRef}
+      />
     </div>
   );
 }

--- a/vite-project/src/features/plan/components/PlanCalendarGrid.tsx
+++ b/vite-project/src/features/plan/components/PlanCalendarGrid.tsx
@@ -1,0 +1,391 @@
+/**
+ * Training Plan — macOS-Calendar-style schedule grid
+ *
+ * Renders the whole plan as one continuous calendar: a Mon–Sun weekday
+ * header, then one 7-column row per training week with hairline gridlines,
+ * date numbers (today gets the filled accent badge), and workouts as tinted
+ * event chips. When an `editor` is provided, chips are draggable to other
+ * days of the same week — drop on an empty day to move, on an occupied day
+ * to swap. One DndContext per week row makes cross-week drags impossible by
+ * construction (weekly volume/progression is a per-week invariant).
+ *
+ * Touch uses a long-press (200ms) activation so normal scrolling over the
+ * grid keeps working; mouse uses a small distance threshold so plain clicks
+ * (e.g. the completion toggle inside a chip) never start a drag.
+ */
+
+import { useMemo, useState, type ReactNode, type Ref } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import type { RunDay, TrainingDay, TrainingPlan, TrainingWeek, Workout } from "../types";
+import { PHASE_META, WORKOUT_META } from "../utils/planDisplay";
+import { todayNoon, workoutDate } from "../utils/planSchedule";
+import type { PlanProgress } from "../hooks/usePlanProgress";
+import type { PlanEditor } from "../hooks/usePlanEditor";
+import { cn } from "@/lib/utils";
+
+const ALL_DAYS: RunDay[] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const DRAG_ID_PREFIX = "drag-";
+
+function dayFromDragId(id: string | number): RunDay {
+  return String(id).replace(DRAG_ID_PREFIX, "") as RunDay;
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/** Tinted macOS-event look: soft wash of the workout hue + saturated accent. */
+function chipColors(workout: Workout): { bg: string; accent: string; text: string } {
+  if (workout.type === "rest") {
+    return { bg: "#f1f5f9", accent: "#cbd5e1", text: "#64748b" };
+  }
+  const meta = WORKOUT_META[workout.type];
+  return { bg: `${meta.bg}1A`, accent: meta.bg, text: meta.bg };
+}
+
+interface ChipProps {
+  workout: Workout;
+  done?: boolean;
+  pending?: boolean;
+  /** Present only for trackable workouts with progress wired in. */
+  onToggle?: () => void;
+  /** Rendered inside DragOverlay — lifted styling. */
+  overlay?: boolean;
+  /** The source chip while its overlay clone is being dragged. */
+  dragging?: boolean;
+}
+
+function WorkoutChip({ workout, done = false, pending = false, onToggle, overlay = false, dragging = false }: ChipProps) {
+  const colors = chipColors(workout);
+  // Terse per-type name ("Easy", "Tempo", "Long") — calendar chips are
+  // narrow; the full label + description live in the tooltip.
+  const displayName = WORKOUT_META[workout.type].name;
+  return (
+    <div
+      title={workout.type === "rest" ? undefined : `${workout.label} — ${workout.description}`}
+      className={cn(
+        "rounded-md px-1.5 py-1 sm:px-2 sm:py-1.5 select-none",
+        overlay && "shadow-xl ring-1 ring-black/10",
+        dragging && "opacity-30",
+        done && "opacity-60"
+      )}
+      style={{ backgroundColor: colors.bg, borderLeft: `3px solid ${colors.accent}` }}
+    >
+      <div className="flex items-start justify-between gap-1">
+        <span
+          className={cn(
+            "min-w-0 truncate text-[10px] sm:text-[11px] font-semibold leading-tight",
+            done && "line-through"
+          )}
+          style={{ color: colors.text }}
+        >
+          {displayName}
+        </span>
+        {onToggle && (
+          <button
+            type="button"
+            onClick={onToggle}
+            disabled={pending}
+            aria-pressed={done}
+            aria-label={`Mark ${workout.label} as ${done ? "not done" : "done"}`}
+            className={cn(
+              "flex-shrink-0 h-3.5 w-3.5 p-0 rounded-full border flex items-center justify-center transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500",
+              done
+                ? "bg-emerald-600 border-emerald-600 text-white"
+                : "bg-white/80 border-slate-300 text-transparent hover:border-emerald-400",
+              pending && "opacity-50 cursor-wait"
+            )}
+          >
+            <svg className="h-2 w-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={4} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          </button>
+        )}
+      </div>
+      {workout.type !== "rest" && workout.distanceKm !== undefined && workout.distanceKm > 0 && (
+        <div
+          className="mt-0.5 text-[9px] sm:text-[10px] font-medium tabular-nums leading-tight opacity-75 truncate"
+          style={{ color: colors.text }}
+        >
+          {workout.distanceKm} km
+          {workout.paceZone && <span className="hidden sm:inline"> · {workout.paceZone}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface DraggableChipProps extends ChipProps {
+  day: RunDay;
+  disabled: boolean;
+}
+
+function DraggableChip({ day, disabled, ...chip }: DraggableChipProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `${DRAG_ID_PREFIX}${day}`,
+    disabled,
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      data-chip
+      aria-label={
+        disabled
+          ? undefined
+          : `${chip.workout.label} on ${day}. Press space or enter to pick up, arrow keys to move, space or enter again to drop on another day.`
+      }
+      className={cn(
+        "touch-manipulation rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-emerald-500",
+        !disabled && "cursor-grab active:cursor-grabbing"
+      )}
+    >
+      <WorkoutChip {...chip} dragging={isDragging} />
+    </div>
+  );
+}
+
+interface DayCellShellProps {
+  day: RunDay;
+  date: Date;
+  isToday: boolean;
+  highlight?: boolean;
+  children?: ReactNode;
+  innerRef?: (node: HTMLElement | null) => void;
+}
+
+/** One calendar cell: date number top-right (macOS style), chip below. */
+function DayCellShell({ day, date, isToday, highlight = false, children, innerRef }: DayCellShellProps) {
+  const dayOfMonth = date.getDate();
+  const label =
+    dayOfMonth === 1
+      ? `${date.toLocaleDateString(undefined, { month: "short" })} 1`
+      : String(dayOfMonth);
+  return (
+    <div
+      ref={innerRef}
+      data-day={day}
+      className={cn(
+        "min-h-[64px] sm:min-h-[84px] p-1 sm:p-1.5 flex flex-col gap-1 transition-colors",
+        highlight && "bg-emerald-50 ring-1 ring-inset ring-emerald-300"
+      )}
+    >
+      <div className="flex justify-end">
+        <span
+          className={cn(
+            "inline-flex items-center justify-center h-4 min-w-4 sm:h-5 sm:min-w-5 px-1 rounded-full text-[9px] sm:text-[10px] tabular-nums leading-none",
+            isToday ? "bg-emerald-600 text-white font-bold" : "text-slate-400 font-medium"
+          )}
+        >
+          {label}
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+interface DroppableDayCellProps extends Omit<DayCellShellProps, "highlight" | "innerRef"> {
+  /** Whether the in-flight drag may drop here (false also when no drag). */
+  validTarget: boolean;
+}
+
+function DroppableDayCell({ day, validTarget, children, ...shell }: DroppableDayCellProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: day, disabled: !validTarget });
+  return (
+    <DayCellShell {...shell} day={day} innerRef={setNodeRef} highlight={isOver && validTarget}>
+      {children}
+    </DayCellShell>
+  );
+}
+
+interface WeekRowProps {
+  plan: TrainingPlan;
+  week: TrainingWeek;
+  isCurrent: boolean;
+  isFirst: boolean;
+  progress?: PlanProgress;
+  editor?: PlanEditor;
+  innerRef?: Ref<HTMLDivElement>;
+}
+
+function WeekRow({ plan, week, isCurrent, isFirst, progress, editor, innerRef }: WeekRowProps) {
+  const [activeDay, setActiveDay] = useState<RunDay | null>(null);
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+    useSensor(KeyboardSensor)
+  );
+
+  const byDay = useMemo(() => {
+    const map = new Map<RunDay, TrainingDay>();
+    for (const d of week.days) map.set(d.day, d);
+    return map;
+  }, [week.days]);
+
+  const today = todayNoon();
+  const phaseMeta = PHASE_META[week.phase];
+  const summary = progress?.weekProgress(week);
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveDay(dayFromDragId(event.active.id));
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const fromDay = dayFromDragId(event.active.id);
+    setActiveDay(null);
+    if (!editor || !event.over) return;
+    editor.moveWorkout({ weekNumber: week.weekNumber, fromDay, toDay: event.over.id as RunDay });
+  }
+
+  const cells = ALL_DAYS.map((day) => {
+    const trainingDay = byDay.get(day);
+    const date = workoutDate(plan, week.weekNumber, day);
+    const isToday = sameDay(date, today);
+
+    const chipInteractions = trainingDay &&
+      trainingDay.workout.type !== "rest" &&
+      progress
+        ? {
+            done: progress.isComplete(week.weekNumber, day),
+            pending: progress.isPending(week.weekNumber, day),
+            onToggle: () => progress.toggle(week.weekNumber, day),
+          }
+        : {};
+
+    if (!editor) {
+      return (
+        <DayCellShell key={day} day={day} date={date} isToday={isToday}>
+          {trainingDay && <WorkoutChip workout={trainingDay.workout} {...chipInteractions} />}
+        </DayCellShell>
+      );
+    }
+
+    const validTarget =
+      activeDay !== null &&
+      editor.canMove({ weekNumber: week.weekNumber, fromDay: activeDay, toDay: day });
+
+    return (
+      <DroppableDayCell key={day} day={day} date={date} isToday={isToday} validTarget={validTarget}>
+        {trainingDay && (
+          <DraggableChip
+            day={day}
+            disabled={trainingDay.workout.type === "race"}
+            workout={trainingDay.workout}
+            {...chipInteractions}
+          />
+        )}
+      </DroppableDayCell>
+    );
+  });
+
+  const row = <div className="grid grid-cols-7 divide-x divide-slate-100">{cells}</div>;
+  const activeWorkout = activeDay ? byDay.get(activeDay)?.workout : undefined;
+
+  return (
+    <div ref={innerRef} data-week={week.weekNumber}>
+      {/* Slim week bar — the calendar's stand-in for macOS's month label:
+          phase dot, week number, volume, and completion at a glance. */}
+      <div
+        className={cn(
+          "flex items-center gap-2 px-2 sm:px-3 py-1.5 border-slate-200 text-[11px] sm:text-xs",
+          !isFirst && "border-t",
+          isCurrent ? "bg-emerald-50" : "bg-slate-50/60"
+        )}
+      >
+        <span className="h-2 w-2 rounded-full flex-shrink-0" style={{ backgroundColor: phaseMeta.bg }} />
+        <span className="font-bold text-slate-700 whitespace-nowrap">Week {week.weekNumber}</span>
+        <span className="text-slate-400 truncate">{phaseMeta.short}</span>
+        {isCurrent && (
+          <span className="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-emerald-600 text-white whitespace-nowrap">
+            NOW
+          </span>
+        )}
+        <span className="ml-auto font-semibold text-emerald-600 tabular-nums whitespace-nowrap">
+          {week.totalKm} km
+        </span>
+        {summary && summary.totalCount > 0 && (
+          <span className="text-slate-400 tabular-nums whitespace-nowrap">
+            {summary.completedCount}/{summary.totalCount}
+          </span>
+        )}
+      </div>
+
+      {!editor ? (
+        <div className="border-t border-slate-100">{row}</div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={() => setActiveDay(null)}
+        >
+          <div className="border-t border-slate-100">{row}</div>
+          <DragOverlay dropAnimation={null}>
+            {activeWorkout ? <WorkoutChip workout={activeWorkout} overlay /> : null}
+          </DragOverlay>
+        </DndContext>
+      )}
+    </div>
+  );
+}
+
+interface Props {
+  plan: TrainingPlan;
+  currentWeekNum: number | null;
+  progress?: PlanProgress;
+  editor?: PlanEditor;
+  /** Attached to the current week's row so the calendar can scroll to it. */
+  currentWeekRef?: Ref<HTMLDivElement>;
+}
+
+export function PlanCalendarGrid({ plan, currentWeekNum, progress, editor, currentWeekRef }: Props) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+      {/* Weekday header — small, uppercase, right-aligned, macOS-style */}
+      <div className="grid grid-cols-7 divide-x divide-slate-100 border-b border-slate-200 bg-white">
+        {ALL_DAYS.map((day) => (
+          <div
+            key={day}
+            className="px-1.5 sm:px-2 py-1.5 text-right text-[9px] sm:text-[10px] font-semibold uppercase tracking-wider text-slate-400"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {plan.weeks.map((week, i) => (
+        <WeekRow
+          key={week.weekNumber}
+          plan={plan}
+          week={week}
+          isCurrent={week.weekNumber === currentWeekNum}
+          isFirst={i === 0}
+          progress={progress}
+          editor={editor}
+          innerRef={week.weekNumber === currentWeekNum ? currentWeekRef : undefined}
+        />
+      ))}
+    </div>
+  );
+}

--- a/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
+++ b/vite-project/src/features/plan/components/TrainingPlanGenerator.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../auth/AuthContext";
 import { usePlanGenerator } from "../hooks/usePlanGenerator";
 import { useSavePlan } from "../hooks/useSavePlan";
 import { usePlanProgress } from "../hooks/usePlanProgress";
+import { usePlanEditor } from "../hooks/usePlanEditor";
 import { PlanInputForm } from "./PlanInputForm";
 import { PlanOverview } from "./PlanOverview";
 import { PlanStats } from "./PlanStats";
@@ -19,7 +20,7 @@ import {
   clearGuestProgress,
 } from "../utils/planPersistence";
 
-import type { GoalRace } from "../types";
+import type { GoalRace, TrainingPlan } from "../types";
 
 type Segment = "thisweek" | "schedule" | "stats";
 
@@ -92,7 +93,7 @@ interface Props {
 
 export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSource, prefillGoal }: Props) {
   const { user, loading: authLoading } = useAuth();
-  const { plan, error, generate, reset } = usePlanGenerator();
+  const { plan, error, generate, updatePlan, reset } = usePlanGenerator();
   const { save, saving, savedId, error: saveError } = useSavePlan();
   // Before save, planId is undefined and progress lives in guest localStorage
   // (even for signed-in users viewing an unsaved plan) — those ticks ride
@@ -121,6 +122,25 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
     setTrackedPlan(plan);
     setUserSegment(null);
   }
+
+  // Schedule edits (drag-reschedule) swap the plan object too — pre-sync the
+  // identity tracker so the edit isn't mistaken for a fresh generate, which
+  // would reset the user's segment tab out from under their drag.
+  const handlePlanEdited = useCallback(
+    (next: TrainingPlan) => {
+      setTrackedPlan(next);
+      updatePlan(next);
+    },
+    [updatePlan]
+  );
+
+  const editor = usePlanEditor({
+    plan,
+    planId: savedId ?? undefined,
+    completed: progress.completed,
+    onPlanChange: handlePlanEdited,
+    onCompletedChange: progress.replaceCompleted,
+  });
   const activeSegment: Segment = userSegment ?? (progress.currentWeekNumber !== null ? "thisweek" : "schedule");
 
   const currentWeek = plan?.weeks.find((w) => w.weekNumber === progress.currentWeekNumber) ?? null;
@@ -251,6 +271,12 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
             </div>
           )}
 
+          {editor.moveError && (
+            <div className="rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {editor.moveError}
+            </div>
+          )}
+
           {/* Segment control is a mobile/tablet affordance only — at lg the
               two-column grid below shows This Week, Schedule, and Stats
               simultaneously, so there's nothing left to switch between. */}
@@ -347,6 +373,7 @@ export function TrainingPlanGenerator({ prefillPaces, prefillGoalTime, prefillSo
                 saving={saving}
                 savedId={savedId}
                 progress={progress}
+                editor={editor}
                 isActive={activeSegment === "schedule"}
               />
             </div>

--- a/vite-project/src/features/plan/hooks/usePlanEditor.ts
+++ b/vite-project/src/features/plan/hooks/usePlanEditor.ts
@@ -1,0 +1,79 @@
+/**
+ * Training Plan — Schedule Editing (drag-reschedule)
+ *
+ * Owns applying a workout move/swap and persisting it: unsaved plans write
+ * the localStorage draft + guest progress map; saved plans update local
+ * state optimistically, then commit the rewritten `weeks` array and the
+ * completion-key migration atomically to Firestore, rolling both back on
+ * failure (same optimistic pattern as usePlanProgress.toggle).
+ */
+
+import { useCallback, useState } from "react";
+import type { TrainingPlan } from "../types";
+import { applyWorkoutMove, canMoveWorkout, type WorkoutMove } from "../utils/planEdit";
+import { saveDraftPlan, writeGuestProgress } from "../utils/planPersistence";
+import { updateTrainingPlanSchedule } from "../actions";
+
+interface UsePlanEditorArgs {
+  plan: TrainingPlan | null;
+  /** Firestore doc id once saved; undefined = unsaved (draft/guest). */
+  planId?: string;
+  /** Current completion map, from usePlanProgress. */
+  completed: Record<string, string>;
+  onPlanChange: (next: TrainingPlan) => void;
+  onCompletedChange: (next: Record<string, string>) => void;
+}
+
+export interface PlanEditor {
+  canMove: (move: WorkoutMove) => boolean;
+  moveWorkout: (move: WorkoutMove) => void;
+  moveError: string | null;
+}
+
+export function usePlanEditor({
+  plan,
+  planId,
+  completed,
+  onPlanChange,
+  onCompletedChange,
+}: UsePlanEditorArgs): PlanEditor {
+  const [moveError, setMoveError] = useState<string | null>(null);
+
+  const canMove = useCallback(
+    (move: WorkoutMove) => (plan ? canMoveWorkout(plan, move) : false),
+    [plan]
+  );
+
+  const moveWorkout = useCallback(
+    (move: WorkoutMove) => {
+      if (!plan) return;
+      const result = applyWorkoutMove(plan, completed, move);
+      if (!result) return;
+
+      const previousPlan = plan;
+      const previousCompleted = completed;
+
+      onPlanChange(result.plan);
+      onCompletedChange(result.completed);
+      setMoveError(null);
+
+      if (planId) {
+        updateTrainingPlanSchedule(planId, result.plan.weeks, result.completionDelta).catch(() => {
+          onPlanChange(previousPlan);
+          onCompletedChange(previousCompleted);
+          setMoveError("Couldn't save that change — check your connection and try again.");
+        });
+      } else {
+        try {
+          saveDraftPlan(result.plan);
+          writeGuestProgress(result.completed);
+        } catch {
+          // localStorage unavailable — the in-memory move still applies.
+        }
+      }
+    },
+    [plan, planId, completed, onPlanChange, onCompletedChange]
+  );
+
+  return { canMove, moveWorkout, moveError };
+}

--- a/vite-project/src/features/plan/hooks/usePlanGenerator.ts
+++ b/vite-project/src/features/plan/hooks/usePlanGenerator.ts
@@ -42,6 +42,13 @@ export function usePlanGenerator() {
     }
   }, []);
 
+  // Replace the in-memory plan after a schedule edit (drag-reschedule).
+  // Persistence is the editor's responsibility (localStorage draft for
+  // unsaved plans, Firestore for saved ones) — this only swaps state.
+  const updatePlan = useCallback((next: TrainingPlan) => {
+    setPlan(next);
+  }, []);
+
   const reset = useCallback(() => {
     setPlan(null);
     setError(null);
@@ -51,5 +58,5 @@ export function usePlanGenerator() {
     clearPendingSave();
   }, []);
 
-  return { plan, error, generate, reset };
+  return { plan, error, generate, updatePlan, reset };
 }

--- a/vite-project/src/features/plan/hooks/usePlanProgress.ts
+++ b/vite-project/src/features/plan/hooks/usePlanProgress.ts
@@ -116,6 +116,13 @@ export function usePlanProgress({ plan, planId }: UsePlanProgressArgs) {
     [plan, planId, completed]
   );
 
+  // Local-state-only replacement used when a schedule edit migrates
+  // completion keys (the workout's tick travels with it to its new day).
+  // The editor owns persisting the migrated map — one writer per storage.
+  const replaceCompleted = useCallback((next: Record<string, string>) => {
+    setCompleted(next);
+  }, []);
+
   const weekProgress = useCallback(
     (week: TrainingWeek): ProgressSummary =>
       summarize(
@@ -151,6 +158,8 @@ export function usePlanProgress({ plan, planId }: UsePlanProgressArgs) {
   );
 
   return {
+    completed,
+    replaceCompleted,
     isComplete,
     toggle,
     isPending,

--- a/vite-project/src/features/plan/utils/planEdit.ts
+++ b/vite-project/src/features/plan/utils/planEdit.ts
@@ -1,0 +1,93 @@
+/**
+ * Training Plan — Schedule Editing (pure logic)
+ *
+ * Moving a workout to another day of the same week. Drop on an empty day =
+ * move; drop on an occupied day = the two entries swap days. Completion
+ * state follows the workout: the `${weekNumber}:${day}` keys in
+ * `completedWorkouts` (see types.ts) are exchanged along with the days, and
+ * a dot-path delta is produced for atomic Firestore migration.
+ *
+ * The race-day workout is immovable — all of the plan's date math anchors on
+ * the race date being the last day of the final week (see planSchedule.ts) —
+ * and in the final week nothing may land after the race's weekday.
+ */
+
+import type { RunDay, TrainingPlan } from "../types";
+import { DAY_OFFSET, workoutKey } from "./planSchedule";
+
+export interface WorkoutMove {
+  weekNumber: number;
+  fromDay: RunDay;
+  toDay: RunDay;
+}
+
+export interface WorkoutMoveResult {
+  plan: TrainingPlan;
+  /** Fully-migrated completion map (local state / guest localStorage). */
+  completed: Record<string, string>;
+  /** Per-key delta for a dot-path Firestore update; null = delete the key. */
+  completionDelta: Record<string, string | null>;
+}
+
+export function canMoveWorkout(plan: TrainingPlan, move: WorkoutMove): boolean {
+  if (move.fromDay === move.toDay) return false;
+  const week = plan.weeks.find((w) => w.weekNumber === move.weekNumber);
+  if (!week) return false;
+
+  const from = week.days.find((d) => d.day === move.fromDay);
+  if (!from) return false;
+  const to = week.days.find((d) => d.day === move.toDay);
+
+  if (from.workout.type === "race" || to?.workout.type === "race") return false;
+
+  const raceDay = week.days.find((d) => d.workout.type === "race")?.day;
+  if (raceDay && DAY_OFFSET[move.toDay] > DAY_OFFSET[raceDay]) return false;
+
+  return true;
+}
+
+/**
+ * Apply a move/swap, returning the next plan + migrated completion state,
+ * or null if the move is invalid. Never mutates its inputs.
+ */
+export function applyWorkoutMove(
+  plan: TrainingPlan,
+  completed: Record<string, string>,
+  move: WorkoutMove
+): WorkoutMoveResult | null {
+  if (!canMoveWorkout(plan, move)) return null;
+
+  const weeks = plan.weeks.map((week) => {
+    if (week.weekNumber !== move.weekNumber) return week;
+    const days = week.days
+      .map((d) => {
+        if (d.day === move.fromDay) return { ...d, day: move.toDay };
+        if (d.day === move.toDay) return { ...d, day: move.fromDay };
+        return d;
+      })
+      .sort((a, b) => DAY_OFFSET[a.day] - DAY_OFFSET[b.day]);
+    return { ...week, days };
+  });
+
+  // Exchange the two slots' completion values (covers both move and swap;
+  // exchanging with an absent value clears the vacated key).
+  const fromKey = workoutKey(move.weekNumber, move.fromDay);
+  const toKey = workoutKey(move.weekNumber, move.toDay);
+  const fromValue = completed[fromKey];
+  const toValue = completed[toKey];
+
+  const nextCompleted = { ...completed };
+  delete nextCompleted[fromKey];
+  delete nextCompleted[toKey];
+  if (toValue) nextCompleted[fromKey] = toValue;
+  if (fromValue) nextCompleted[toKey] = fromValue;
+
+  return {
+    plan: { ...plan, weeks },
+    completed: nextCompleted,
+    completionDelta: {
+      [fromKey]: toValue ?? null,
+      [toKey]: fromValue ?? null,
+    },
+  };
+}


### PR DESCRIPTION
## What

The generated training plan was fully prescriptive — workouts were locked to their auto-assigned days and the only escape hatch was "Start over". The Schedule view is now a macOS-Calendar-style grid (Mon–Sun columns, hairline gridlines, date numbers with a today badge, workouts as tinted event chips), and chips drag to other days of the same week: drop on an empty day to move, on an occupied day to swap.

## How

- **`utils/planEdit.ts`** — pure move/swap logic: day reassignment with re-sort, completion-key migration (`"3:Tue" → "3:Wed"`, ticks travel with the workout), race-day guards (race chip immovable; final week can't schedule past race day).
- **`hooks/usePlanEditor.ts`** — optimistic apply + persistence: localStorage draft for unsaved/guest plans, one atomic Firestore `updateDoc` (rewritten `weeks` + dot-path completion migration) for saved plans, with rollback + error banner on failure (mirrors `usePlanProgress.toggle`).
- **`components/PlanCalendarGrid.tsx`** — the calendar grid, replacing the WeekCard accordion inside `PlanCalendar` only. One `DndContext` per week row makes cross-week drags impossible by construction. Touch = long-press (scrolling preserved), mouse = small distance threshold (clicks still toggle completion), keyboard drag supported. `WeekCard` is untouched for This Week / dashboard rendering.
- New dependency: `@dnd-kit/core` (~12 kB gz).

## Testing

- `npm run build` + `npm run lint` clean.
- Playwright: 2 new e2e tests — drag to an empty day (asserts persistence across a fresh navigation via the localStorage draft) and swap between two occupied days. Full `training-plan.spec.ts` suite passes (8/8).

## Notes

- Within-week moves only (weekly volume progression is the plan's backbone).
- Dashboard plans stay read-only; the editor hook + grid are reusable there as a follow-up.
- A re-export of the .ics after a move produces a new UID for the moved event (UIDs embed the day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111NeFJCgu1dRxruKuQ2aRi

---
_Generated by [Claude Code](https://claude.ai/code/session_0111NeFJCgu1dRxruKuQ2aRi)_