### PR TITLE
feat(conditions): heat, humidity & altitude race day calculator

### DIFF
--- a/vite-project/public/sitemap.xml
+++ b/vite-project/public/sitemap.xml
@@ -2,325 +2,331 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.trainpace.com/</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/vdot</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.trainpace.com/conditions</loc>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevation-finder</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/dashboard</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/about</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/mcp</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/faq</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/privacy</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/terms</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/boston</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/nyc</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/chicago</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/berlin</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/london</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/tokyo</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/sydney</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/preview-route/oslo</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/how-to-build-a-training-plan-for-your-goal-race</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/how-to-pace-a-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/what-is-vdot-and-how-to-use-it</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/same-time-different-race-bmo-vancouver-2026</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/understanding-vdot-training-paces</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/marathon-fueling-complete-guide</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/elevation-impact-race-strategy</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/beginner-marathon-training-tips</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/recovery-strategies-for-runners</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/tempo-runs-explained</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/running-shoes-guide</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/half-marathon-pacing-strategy</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/strength-training-for-runners</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/taper-marathon-guide</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/why-easy-runs-feel-too-slow</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/day-after-hard-workout-recovery</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/how-to-pace-a-5k-without-blowing-up</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/winter-running-dark-wet-mornings</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/build-mileage-without-breaking-down</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/long-run-mistakes-that-cost-confidence</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/what-i-eat-before-early-morning-runs</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/race-morning-nerves-what-actually-helps</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/running-form-cues-when-legs-get-tired</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/running-cadence-guide</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/running-in-the-rain-without-being-miserable</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/carb-loading-for-runners-what-actually-works</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/how-to-run-your-first-5k</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/vo2max-intervals-for-runners</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/10k-race-strategy-how-to-run-a-pr</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/how-to-break-through-a-running-plateau</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/blog/overtraining-signs-and-recovery</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -328,1177 +334,1177 @@
   <!-- Programmatic SEO Pages -->
   <url>
     <loc>https://www.trainpace.com/calculator/5k-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/10k-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/half-marathon-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/marathon-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/vdot-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/easy-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/tempo-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/threshold-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/mile-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/8k-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/15k-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/20k-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/30k-pace-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/km-to-mile-pace-converter</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-20-5k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-90-half-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-4-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-3-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-3-15-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-3-30-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-3-45-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-4-30-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-5-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-1-20-half-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-1-30-half-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-1-45-half-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-2-hour-half-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-2-15-half-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-2-30-half-marathon-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-18-5k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-25-5k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-30-5k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-40-10k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-45-10k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-50-10k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/sub-60-10k-pace</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/trainpace-vs-runna</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/free-runna-alternative</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/trainpace-vs-trainingpeaks</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/free-trainingpeaks-alternative</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/calculator/strava-vs-trainpace-for-training</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/marathon-fueling-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/half-marathon-fueling-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/how-many-gels-for-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/how-many-gels-for-half-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/carbs-per-hour-running</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/marathon-nutrition-timing</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/avoid-hitting-the-wall</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/carb-loading-for-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/marathon-hydration-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/fueling-for-hilly-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/gel-timing-every-30-minutes</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/half-marathon-fueling-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/marathon-fueling-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/maurten-fuel-planner</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/fuel/carbs-per-hour-running-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/gpx-elevation-profile-analyzer</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/elevation-gain-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/how-to-read-elevation-profile</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/route-difficulty-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/strava-gpx-analyzer</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/hilly-course-pacing</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/marathon-course-elevation</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/grade-percentage-calculator</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/garmin-gpx-analyzer</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/coros-gpx-analyzer</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/trail-running-elevation</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/elevationfinder/guides/hill-repeats-planning</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/boston-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/nyc-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/chicago-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/berlin-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/london-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/tokyo-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/sydney-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/paris-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/amsterdam-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/valencia-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/barcelona-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/rome-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/vienna-city-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/prague-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/dublin-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/edinburgh-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/copenhagen-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/stockholm-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/oslo-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/helsinki-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/athens-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/istanbul-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/dubai-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/seoul-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/singapore-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/shanghai-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/osaka-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/nagoya-womens-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/fukuoka-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/honolulu-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/los-angeles-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/san-francisco-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/seattle-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/portland-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/houston-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/austin-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/miami-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/philadelphia-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/marine-corps-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/twin-cities-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/detroit-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/indianapolis-monumental-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/california-international-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/big-sur-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/grandmas-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/st-george-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/reykjavik-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/cape-town-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/johannesburg-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/buenos-aires-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/rio-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/toronto-waterfront-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/vancouver-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/ottawa-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/montreal-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/rotterdam-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/manchester-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/brighton-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/geneva-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/zurich-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/venice-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/florence-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/naples-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/brussels-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/bruges-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/rotterdam-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/new-orleans-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/savannah-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/charleston-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/nashville-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/atlanta-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/phoenix-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/mesa-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/tucson-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/jacksonville-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/st-louis-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/kansas-city-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/cleveland-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/pittsburgh-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/richmond-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/newport-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/providence-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/salt-lake-city-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/denver-colfax-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/nyc-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/brooklyn-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/houston-half-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/austin-half-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/philadelphia-half-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/chicago-half-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/san-francisco-half-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/rbc-brooklyn-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/las-vegas-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/nashville-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/san-diego-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/dc-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/copenhagen-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/barcelona-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/paris-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/berlin-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/lisbon-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/dublin-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/edinburgh-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/amsterdam-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/valencia-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/cairns-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/pittsburgh-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/richmond-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/cleveland-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/denver-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/san-jose-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/san-antonio-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/new-orleans-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/miami-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/seattle-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/portland-half</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/5k</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/10k</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/half-marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/race/marathon</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/marathon-training-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/half-marathon-training-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/10k-training-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/5k-training-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/marathon-training-plan-beginners</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/16-week-marathon-training-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/20-week-marathon-training-plan</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.trainpace.com/plan/half-marathon-training-plan-beginners</loc>
-    <lastmod>2026-07-23</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/vite-project/scripts/generateSitemap.ts
+++ b/vite-project/scripts/generateSitemap.ts
@@ -10,6 +10,7 @@ const staticPaths: Array<{ loc: string; changefreq: string; priority: string }> 
   { loc: `${BASE_URL}/`, changefreq: "weekly", priority: "1.0" },
   { loc: `${BASE_URL}/calculator`, changefreq: "monthly", priority: "0.9" },
   { loc: `${BASE_URL}/vdot`, changefreq: "monthly", priority: "0.9" },
+  { loc: `${BASE_URL}/conditions`, changefreq: "monthly", priority: "0.9" },
   { loc: `${BASE_URL}/fuel`, changefreq: "monthly", priority: "0.9" },
   { loc: `${BASE_URL}/plan`, changefreq: "monthly", priority: "0.9" },
   { loc: `${BASE_URL}/elevation-finder`, changefreq: "monthly", priority: "0.8" },

--- a/vite-project/src/App.tsx
+++ b/vite-project/src/App.tsx
@@ -38,6 +38,7 @@ const About = lazy(() => import("./pages/About"));
 const McpDocs = lazy(() => import("./pages/McpDocs"));
 const DashboardV2 = lazy(() => import("./pages/DashboardV2"));
 const VdotCalculatorPage = lazy(() => import("./pages/VdotCalculatorPage"));
+const ConditionsCalculatorPage = lazy(() => import("./pages/ConditionsCalculatorPage"));
 const Onboarding = lazy(() => import("./pages/Onboarding"));
 const TrainingPlanPage = lazy(() => import("./pages/TrainingPlanPage"));
 const BlogList = lazy(() =>
@@ -64,6 +65,7 @@ function App() {
           <Route path="/fuel" element={<FuelPlannerPage />} />
           <Route path="/fuel/:seoSlug" element={<FuelSeoLanding />} />
           <Route path="/vdot" element={<VdotCalculatorPage />} />
+          <Route path="/conditions" element={<ConditionsCalculatorPage />} />
           <Route path="/plan" element={<TrainingPlanPage />} />
           <Route path="/plan/:seoSlug" element={<PlanSeoLanding />} />
           <Route path="/race" element={<RaceIndex />} />

--- a/vite-project/src/components/layout/SideNav.tsx
+++ b/vite-project/src/components/layout/SideNav.tsx
@@ -11,6 +11,7 @@ export default function SideNav() {
     { href: "/", label: "Home" },
     { href: "/calculator", label: "Calculator" },
     { href: "/vdot", label: "VDOT Calculator" },
+    { href: "/conditions", label: "Race Day Conditions" },
     { href: "/fuel", label: "Fuel Planner" },
     { href: "/elevation-finder", label: "Elevation Finder" },
     { href: "/plan", label: "Training Plan" },

--- a/vite-project/src/components/layout/constants/navLinks.ts
+++ b/vite-project/src/components/layout/constants/navLinks.ts
@@ -8,4 +8,5 @@ export interface NavLinkItem {
     { label: 'Dashboard', path: '/dashboard' },
     { label: 'Races', path: '/races' },
     { label: 'Fuel Planner', path: '/fuel' },
+    { label: 'Race Day Conditions', path: '/conditions' },
   ];

--- a/vite-project/src/components/ui/slider.tsx
+++ b/vite-project/src/components/ui/slider.tsx
@@ -3,10 +3,19 @@ import * as SliderPrimitive from "@radix-ui/react-slider";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * `thumbLabel` names the draggable thumb rather than the wrapper. The thumb is
+ * the element that actually receives focus and carries role="slider", so an
+ * aria-label on the root leaves it announced as an unnamed control.
+ */
+type SliderProps = React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+  thumbLabel?: string;
+};
+
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+  SliderProps
+>(({ className, thumbLabel, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +27,7 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-gray-200">
       <SliderPrimitive.Range className="absolute h-full bg-emerald-600" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-emerald-600 bg-white shadow-md ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-grab active:cursor-grabbing" />
+    <SliderPrimitive.Thumb aria-label={thumbLabel} className="block h-5 w-5 rounded-full border-2 border-emerald-600 bg-white shadow-md ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-grab active:cursor-grabbing" />
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/vite-project/src/features/conditions/components/AdjustedZonesTable.tsx
+++ b/vite-project/src/features/conditions/components/AdjustedZonesTable.tsx
@@ -1,0 +1,113 @@
+/**
+ * AdjustedZonesTable — "what pace should I actually run today?"
+ *
+ * The race prediction is the headline, but this is the part most people will
+ * use week to week. Each zone carries its own heat penalty because a 90-minute
+ * long run and a set of 400m reps are not equally exposed — showing one blanket
+ * adjustment for all five zones is what makes most hot-weather pace charts
+ * feel wrong to experienced runners.
+ */
+
+import { cn } from "@/lib/utils";
+import { formatPace } from "@/features/vdot-calculator/vdot-math";
+import type { AdjustedZone, PaceUnit } from "../types";
+
+const ZONE_ACCENT: Record<string, string> = {
+  emerald: "bg-emerald-500",
+  blue: "bg-blue-500",
+  yellow: "bg-yellow-500",
+  orange: "bg-orange-500",
+  red: "bg-red-500",
+};
+
+interface Props {
+  zones: AdjustedZone[];
+  paceUnit: PaceUnit;
+  onTogglePaceUnit: () => void;
+}
+
+export function AdjustedZonesTable({
+  zones,
+  paceUnit,
+  onTogglePaceUnit,
+}: Props) {
+  if (zones.length === 0) return null;
+  const perKm = paceUnit === "km";
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg border-0 p-5 sm:p-6">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+            Today&rsquo;s training paces
+          </h2>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Your normal zones, re-targeted for these conditions.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onTogglePaceUnit}
+          className="flex-shrink-0 text-[11px] font-semibold text-emerald-700 bg-emerald-50 hover:bg-emerald-100 border border-emerald-200 rounded-full px-2.5 py-1 transition-colors"
+        >
+          min/{paceUnit}
+        </button>
+      </div>
+
+      <div className="space-y-1.5">
+        {zones.map((zone) => {
+          const base = perKm
+            ? zone.basePacePerKmSeconds
+            : zone.basePacePerMileSeconds;
+          const adjusted = perKm
+            ? zone.adjustedPacePerKmSeconds
+            : zone.adjustedPacePerMileSeconds;
+          const changed = Math.round(adjusted[0] - base[0]) >= 1;
+
+          return (
+            <div
+              key={zone.name}
+              className="flex items-center gap-3 rounded-xl border border-gray-100 bg-slate-50/60 px-3 py-2.5"
+              title={zone.description}
+            >
+              <span
+                className={cn(
+                  "flex-shrink-0 w-7 h-7 rounded-lg grid place-items-center text-xs font-black text-white",
+                  ZONE_ACCENT[zone.color] ?? "bg-gray-400"
+                )}
+              >
+                {zone.shortName}
+              </span>
+
+              <span className="flex-1 text-sm font-semibold text-gray-800 min-w-0 truncate">
+                {zone.name}
+              </span>
+
+              {changed && (
+                <span className="hidden sm:inline text-xs text-gray-400 tabular-nums line-through decoration-1">
+                  {formatPace(base[0])}–{formatPace(base[1])}
+                </span>
+              )}
+
+              <span
+                className={cn(
+                  "text-sm font-bold tabular-nums whitespace-nowrap",
+                  changed ? "text-emerald-700" : "text-gray-700"
+                )}
+              >
+                {formatPace(adjusted[0])}–{formatPace(adjusted[1])}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="text-[11px] text-gray-400 mt-3 leading-relaxed">
+        Easy and long-run paces move the most — they&rsquo;re the sessions where
+        heat has time to accumulate. Short reps barely shift, so resist the urge
+        to chase interval splits on a hot day; the effort is already higher than
+        the watch suggests.
+      </p>
+    </div>
+  );
+}

--- a/vite-project/src/features/conditions/components/ConditionsCalculator.tsx
+++ b/vite-project/src/features/conditions/components/ConditionsCalculator.tsx
@@ -1,0 +1,215 @@
+/**
+ * ConditionsCalculator — orchestrator for the race day conditions tool.
+ *
+ * Dashboard layout: inputs and answer side by side, so adjusting the forecast
+ * and watching the finish time move is a single glance rather than a scroll.
+ */
+
+import { Link } from "react-router-dom";
+import { CloudSun } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+import { useConditionsCalculator } from "../hooks/useConditionsCalculator";
+import type { ConditionsFormState } from "../types";
+import { ConditionsSeoHead } from "./ConditionsSeoHead";
+import { ConditionsInputPanel } from "./ConditionsInputPanel";
+import { formatDewPoint } from "../utils";
+import { ConditionsVerdict } from "./ConditionsVerdict";
+import { TemperatureCurveChart } from "./TemperatureCurveChart";
+import { AdjustedZonesTable } from "./AdjustedZonesTable";
+import { ConditionsFaq } from "./ConditionsFaq";
+
+export interface ConditionsCalculatorProps {
+  initialForm?: Partial<ConditionsFormState>;
+}
+
+export function ConditionsCalculator({
+  initialForm,
+}: ConditionsCalculatorProps = {}) {
+  const {
+    form,
+    paceUnit,
+    input,
+    isValid,
+    result,
+    adjustedZones,
+    sensitivity,
+    setField,
+    selectDistance,
+    setTimePart,
+    toggleTempUnit,
+    toggleAltitudeUnit,
+    applyPreset,
+    togglePaceUnit,
+  } = useConditionsCalculator(initialForm);
+
+  return (
+    <>
+      <ConditionsSeoHead />
+
+      {/* text-left resets the global `#root { text-align: center }` inherited
+          from the Vite template; individually centred elements opt back in. */}
+      <div className="min-h-screen text-left bg-gradient-to-br from-slate-50 via-white to-sky-50/40 p-4 md:p-6">
+        <div className="max-w-7xl mx-auto">
+          {/* Hero */}
+          <header className="mb-5 sm:mb-6">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-orange-100 text-orange-700 text-xs font-semibold mb-3">
+              <CloudSun className="w-3.5 h-3.5" />
+              Race Day Conditions
+            </div>
+            <h1 className="text-2xl sm:text-3xl font-black text-gray-900 tracking-tight">
+              What will the weather cost you?
+            </h1>
+            <p className="text-sm sm:text-base text-gray-500 mt-1.5 max-w-2xl">
+              Heat, humidity, and altitude all take time off a goal that was set
+              in perfect conditions. Set the forecast and get a finish time you
+              can actually race to &mdash; plus the paces to train at until then.
+            </p>
+          </header>
+
+          {/*
+            Dashboard. Explicit `order` on mobile keeps the answer directly
+            under the inputs that produced it — stacking two nested columns
+            would otherwise bury the verdict below the training-pace table.
+            At lg the four cards resolve to a 2x2 grid.
+          */}
+          <div className="flex flex-col gap-4 lg:grid lg:grid-cols-12 lg:items-start">
+            <div className="order-1 lg:col-span-5 lg:col-start-1 lg:row-start-1">
+              <ConditionsInputPanel
+                form={form}
+                dewPointDisplay={formatDewPoint(
+                  input.tempC,
+                  input.humidity,
+                  form.tempUnit
+                )}
+                onSelectDistance={selectDistance}
+                onTimePartChange={setTimePart}
+                onFieldChange={setField}
+                onToggleTempUnit={toggleTempUnit}
+                onToggleAltitudeUnit={toggleAltitudeUnit}
+                onApplyPreset={applyPreset}
+              />
+            </div>
+
+            <div className="order-2 lg:col-span-7 lg:col-start-6 lg:row-start-1">
+              {result ? (
+                <ConditionsVerdict
+                  result={result}
+                  distanceName={form.distanceName}
+                  paceUnit={paceUnit}
+                  onTogglePaceUnit={togglePaceUnit}
+                />
+              ) : (
+                <div className="bg-white rounded-2xl shadow-lg p-8 text-center">
+                  <p className="text-sm text-gray-500">
+                    {isValid
+                      ? "Working…"
+                      : "Enter a realistic goal time for the selected distance to see your adjusted race."}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {result && (
+              <div className="order-3 lg:col-span-7 lg:col-start-6 lg:row-start-2">
+                <TemperatureCurveChart
+                  points={sensitivity}
+                  currentTempC={input.tempC}
+                  currentTimeSeconds={result.adjustedTimeSeconds}
+                  goalTimeSeconds={result.goalTimeSeconds}
+                  tempUnit={form.tempUnit}
+                />
+              </div>
+            )}
+
+            {result && (
+              <div className="order-4 lg:col-span-5 lg:col-start-1 lg:row-start-2">
+                <AdjustedZonesTable
+                  zones={adjustedZones}
+                  paceUnit={paceUnit}
+                  onTogglePaceUnit={togglePaceUnit}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Explainer + related tools */}
+          <div className="mt-10 space-y-6">
+            <ConditionsFaq />
+
+            <Card className="bg-white rounded-2xl shadow-sm border-0">
+              <CardContent className="p-6">
+                <h2 className="text-lg font-semibold text-gray-900 mb-3">
+                  Related Tools
+                </h2>
+                <div className="grid sm:grid-cols-2 gap-3">
+                  <RelatedTool
+                    to="/vdot"
+                    emoji="📈"
+                    title="VDOT Calculator"
+                    blurb="Find your goal time from a recent race"
+                    tone="emerald"
+                  />
+                  <RelatedTool
+                    to="/fuel"
+                    emoji="⚡"
+                    title="Fuel Planner"
+                    blurb="Hydration and carbs for hot races"
+                    tone="emerald"
+                  />
+                  <RelatedTool
+                    to="/elevation-finder"
+                    emoji="⛰️"
+                    title="Elevation Finder"
+                    blurb="What the course itself will cost you"
+                    tone="orange"
+                  />
+                  <RelatedTool
+                    to="/plan"
+                    emoji="🗓️"
+                    title="Training Plan"
+                    blurb="Build a week-by-week plan to your goal"
+                    tone="purple"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+const TONES: Record<string, string> = {
+  emerald: "bg-emerald-50 border-emerald-100 hover:border-emerald-300",
+  orange: "bg-orange-50 border-orange-100 hover:border-orange-300",
+  purple: "bg-purple-50 border-purple-100 hover:border-purple-300",
+};
+
+function RelatedTool({
+  to,
+  emoji,
+  title,
+  blurb,
+  tone,
+}: {
+  to: string;
+  emoji: string;
+  title: string;
+  blurb: string;
+  tone: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className={`flex items-center gap-3 p-3 rounded-xl border hover:shadow-sm transition-all ${TONES[tone]}`}
+    >
+      <span className="text-2xl">{emoji}</span>
+      <div>
+        <p className="font-medium text-gray-900">{title}</p>
+        <p className="text-sm text-gray-600">{blurb}</p>
+      </div>
+    </Link>
+  );
+}

--- a/vite-project/src/features/conditions/components/ConditionsFaq.tsx
+++ b/vite-project/src/features/conditions/components/ConditionsFaq.tsx
@@ -1,0 +1,109 @@
+/**
+ * ConditionsFaq — the reasoning behind the numbers, kept visible for SEO and
+ * because a prediction a runner doesn't understand is a prediction they won't
+ * trust on start line morning.
+ */
+
+import { Link } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
+
+export function ConditionsFaq() {
+  return (
+    <div className="bg-white rounded-2xl shadow-lg p-5 sm:p-8 space-y-6">
+      <div>
+        <h2 className="text-xl sm:text-2xl font-bold text-gray-900">
+          Racing in heat and at altitude
+        </h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Why the forecast changes your goal, and what to do about it
+        </p>
+      </div>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-gray-900">
+          Why dew point, not humidity
+        </h3>
+        <p className="text-sm text-gray-600 leading-relaxed">
+          Relative humidity on its own tells you almost nothing &mdash; 90% at
+          10&deg;C is a pleasant morning, 60% at 30&deg;C is punishing.{" "}
+          <strong>Dew point</strong> measures how much moisture the air actually
+          holds, which sets the ceiling on evaporation. Sweat only cools you when
+          it evaporates; when the dew point is high, it just runs off you and
+          your core temperature keeps climbing. That&rsquo;s why this calculator
+          works from the sum of air temperature and dew point rather than from
+          the temperature you see on the forecast app.
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-gray-900">
+          Why the marathon suffers more than the 5K
+        </h3>
+        <p className="text-sm text-gray-600 leading-relaxed">
+          Heat is cumulative. A 5K finishes before core temperature has climbed
+          far, so the penalty stays small. A marathon spends three or four hours
+          generating heat faster than the body can shed it, and the cost
+          compounds &mdash; which is why the same forecast might cost you 30
+          seconds over 5K and eight minutes over 42.2K. This calculator scales
+          the penalty by how long you&rsquo;ll actually be out there rather than
+          applying one flat percentage.
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-gray-900">
+          What altitude does
+        </h3>
+        <p className="text-sm text-gray-600 leading-relaxed">
+          Thinner air means less oxygen per breath, so VO&#8322;max drops &mdash;
+          roughly 1.8% for every 300 m above about 300 m of elevation, for a
+          runner arriving from sea level. Because that&rsquo;s a hit to aerobic
+          capacity rather than to cooling, we model it by reducing your VDOT and
+          re-predicting the race from there, which is why the altitude penalty
+          grows naturally with distance. Two or more weeks living at elevation
+          recovers part of the deficit, but never all of it &mdash; tick the
+          acclimatised box to see the difference.
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-gray-900">
+          How to race it
+        </h3>
+        <p className="text-sm text-gray-600 leading-relaxed">
+          The single biggest mistake in a hot race is going out at the original
+          goal pace and hoping. Heat penalties are not linear: a runner who
+          banks time early pays it back with interest, because once core
+          temperature is elevated you cannot recover it mid-race. Start at the
+          adjusted pace, take fluid early rather than when you feel thirsty, and
+          pour water on your head and forearms &mdash; skin cooling buys real
+          time. Then reassess at halfway, when you know what kind of day it is.
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-gray-900">
+          How accurate is this?
+        </h3>
+        <p className="text-sm text-gray-600 leading-relaxed">
+          It&rsquo;s a well-supported estimate of the <em>typical</em> response,
+          not a promise. Individual heat tolerance varies widely, and runners who
+          have trained through a hot summer handle the same conditions better
+          than someone stepping off a plane from a cold climate. Sun exposure,
+          wind, and a shaded versus open course all shift the number too. Treat
+          the adjusted time as a realistic target band, not a split to defend.
+        </p>
+      </section>
+
+      <div className="pt-2 border-t border-gray-100">
+        <Link
+          to="/vdot"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-emerald-700 hover:text-emerald-800 transition-colors"
+        >
+          Don&rsquo;t know your goal time yet? Start with the VDOT calculator
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/vite-project/src/features/conditions/components/ConditionsInputPanel.tsx
+++ b/vite-project/src/features/conditions/components/ConditionsInputPanel.tsx
@@ -1,0 +1,216 @@
+/**
+ * ConditionsInputPanel — goal race + forecast inputs.
+ *
+ * Temperature and humidity are sliders rather than text boxes on purpose:
+ * the interesting question is rarely "what happens at exactly 24°C" but
+ * "how much worse does this get if the forecast is wrong by a few degrees",
+ * and a slider invites that exploration.
+ */
+
+import { Thermometer, Droplets, Mountain } from "lucide-react";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
+import type { ConditionsFormState } from "../types";
+import { CONDITION_DISTANCES, CONDITION_PRESETS } from "../types";
+
+interface Props {
+  form: ConditionsFormState;
+  dewPointDisplay: string;
+  onSelectDistance: (meters: number, name: string) => void;
+  onTimePartChange: (
+    field: "hours" | "minutes" | "seconds",
+    value: string
+  ) => void;
+  onFieldChange: <K extends keyof ConditionsFormState>(
+    field: K,
+    value: ConditionsFormState[K]
+  ) => void;
+  onToggleTempUnit: () => void;
+  onToggleAltitudeUnit: () => void;
+  onApplyPreset: (tempC: number, humidity: number, label: string) => void;
+}
+
+/** Slider bounds, expressed in whichever unit is currently displayed. */
+const TEMP_RANGE = { C: { min: -10, max: 45 }, F: { min: 14, max: 113 } };
+
+export function ConditionsInputPanel({
+  form,
+  dewPointDisplay,
+  onSelectDistance,
+  onTimePartChange,
+  onFieldChange,
+  onToggleTempUnit,
+  onToggleAltitudeUnit,
+  onApplyPreset,
+}: Props) {
+  const tempValue = parseFloat(form.temp) || 0;
+  const humidityValue = parseFloat(form.humidity) || 0;
+  const range = TEMP_RANGE[form.tempUnit];
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg border-0 p-5 sm:p-6 space-y-6">
+      {/* ── Goal race ── */}
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+          Your goal
+        </h2>
+
+        <div className="flex flex-wrap gap-2">
+          {CONDITION_DISTANCES.map((d) => (
+            <button
+              key={d.name}
+              type="button"
+              onClick={() => onSelectDistance(d.meters, d.name)}
+              className={cn(
+                "px-3 py-1.5 rounded-full text-xs font-semibold border transition-all",
+                form.distanceMeters === d.meters
+                  ? "bg-emerald-600 border-emerald-600 text-white shadow-sm"
+                  : "bg-white border-gray-200 text-gray-600 hover:border-emerald-300 hover:bg-emerald-50"
+              )}
+            >
+              {d.name}
+            </button>
+          ))}
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-500 mb-1.5">
+            Goal finish time (perfect conditions)
+          </label>
+          <div className="flex items-center gap-1.5">
+            {(["hours", "minutes", "seconds"] as const).map((part, i) => (
+              <div key={part} className="flex items-center gap-1.5">
+                {i > 0 && <span className="text-gray-300 font-bold">:</span>}
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  aria-label={`Goal ${part}`}
+                  value={form[part]}
+                  onChange={(e) => onTimePartChange(part, e.target.value)}
+                  placeholder={part === "hours" ? "h" : part === "minutes" ? "mm" : "ss"}
+                  className="w-14 sm:w-16 text-center text-lg font-bold tabular-nums border border-gray-200 rounded-lg py-2 focus:border-emerald-400 focus:ring-2 focus:ring-emerald-100 outline-none transition-all"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-gray-100" />
+
+      {/* ── Forecast ── */}
+      <div className="space-y-5">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+            Race day forecast
+          </h2>
+          <button
+            type="button"
+            onClick={onToggleTempUnit}
+            className="text-xs font-semibold text-emerald-700 bg-emerald-50 hover:bg-emerald-100 border border-emerald-200 rounded-full px-2.5 py-1 transition-colors"
+          >
+            °{form.tempUnit}
+          </button>
+        </div>
+
+        {/* Presets */}
+        <div className="flex flex-wrap gap-1.5">
+          {CONDITION_PRESETS.map((p) => (
+            <button
+              key={p.label}
+              type="button"
+              onClick={() => onApplyPreset(p.tempC, p.humidity, p.label)}
+              className="px-2.5 py-1 rounded-lg text-[11px] font-medium bg-slate-50 border border-slate-200 text-slate-600 hover:border-emerald-300 hover:bg-emerald-50 hover:text-emerald-700 transition-all"
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Temperature */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+              <Thermometer className="w-3.5 h-3.5 text-orange-500" />
+              Temperature
+            </span>
+            <span className="text-sm font-bold text-gray-900 tabular-nums">
+              {Math.round(tempValue)}°{form.tempUnit}
+            </span>
+          </div>
+          <Slider
+            value={[tempValue]}
+            min={range.min}
+            max={range.max}
+            step={1}
+            thumbLabel="Temperature"
+            onValueChange={([v]) => onFieldChange("temp", String(v))}
+          />
+        </div>
+
+        {/* Humidity */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+              <Droplets className="w-3.5 h-3.5 text-sky-500" />
+              Relative humidity
+            </span>
+            <span className="text-sm font-bold text-gray-900 tabular-nums">
+              {Math.round(humidityValue)}%
+            </span>
+          </div>
+          <Slider
+            value={[humidityValue]}
+            min={0}
+            max={100}
+            step={1}
+            thumbLabel="Relative humidity"
+            onValueChange={([v]) => onFieldChange("humidity", String(v))}
+          />
+          <p className="text-[11px] text-gray-400">
+            Dew point {dewPointDisplay} — this, not temperature alone, is what
+            caps how well you can cool yourself.
+          </p>
+        </div>
+
+        {/* Altitude */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+              <Mountain className="w-3.5 h-3.5 text-violet-500" />
+              Race elevation
+            </span>
+            <button
+              type="button"
+              onClick={onToggleAltitudeUnit}
+              className="text-[11px] font-semibold text-violet-700 bg-violet-50 hover:bg-violet-100 border border-violet-200 rounded-full px-2 py-0.5 transition-colors"
+            >
+              {form.altitudeUnit}
+            </button>
+          </div>
+          <input
+            type="text"
+            inputMode="numeric"
+            aria-label="Race elevation"
+            value={form.altitude}
+            onChange={(e) =>
+              onFieldChange("altitude", e.target.value.replace(/[^\d]/g, ""))
+            }
+            className="w-full text-sm font-semibold tabular-nums border border-gray-200 rounded-lg px-3 py-2 focus:border-violet-400 focus:ring-2 focus:ring-violet-100 outline-none transition-all"
+          />
+          <label className="flex items-center gap-2 pt-1 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.acclimatised}
+              onChange={(e) => onFieldChange("acclimatised", e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-violet-600 focus:ring-violet-400"
+            />
+            <span className="text-xs text-gray-600">
+              I&rsquo;ve lived at this altitude for 2+ weeks
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/vite-project/src/features/conditions/components/ConditionsSeoHead.tsx
+++ b/vite-project/src/features/conditions/components/ConditionsSeoHead.tsx
@@ -1,0 +1,113 @@
+/**
+ * ConditionsSeoHead — meta tags and structured data for the conditions calculator.
+ */
+
+import { Helmet } from "react-helmet-async";
+
+const TITLE = "Heat & Altitude Pace Calculator | TrainPace";
+const DESCRIPTION =
+  "See how heat, humidity, and altitude change your race time. Enter your goal and the forecast to get an adjusted finish time, race-day pace, and re-targeted training paces.";
+const URL = "https://www.trainpace.com/conditions";
+const IMAGE = "https://trainpace.com/landing-page-2025.png";
+
+export function ConditionsSeoHead() {
+  return (
+    <Helmet>
+      <title>{TITLE}</title>
+      <meta name="description" content={DESCRIPTION} />
+      <link rel="canonical" href={URL} />
+      {/* Open Graph */}
+      <meta property="og:title" content={TITLE} />
+      <meta property="og:description" content={DESCRIPTION} />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={URL} />
+      <meta property="og:image" content={IMAGE} />
+      <meta property="og:site_name" content="TrainPace" />
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={TITLE} />
+      <meta name="twitter:description" content={DESCRIPTION} />
+      <meta name="twitter:image" content={IMAGE} />
+      {/* Structured Data */}
+      <script type="application/ld+json">
+        {JSON.stringify({
+          "@context": "https://schema.org",
+          "@graph": [
+            {
+              "@type": "WebApplication",
+              name: "Heat & Altitude Pace Calculator",
+              url: URL,
+              applicationCategory: "HealthApplication",
+              operatingSystem: "Any",
+              offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+              description:
+                "Adjust your goal race time and training paces for temperature, humidity, and altitude.",
+            },
+            {
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  name: "Home",
+                  item: "https://trainpace.com/",
+                },
+                {
+                  "@type": "ListItem",
+                  position: 2,
+                  name: "Race Day Conditions",
+                  item: URL,
+                },
+              ],
+            },
+            {
+              "@type": "FAQPage",
+              mainEntity: [
+                {
+                  "@type": "Question",
+                  name: "How much slower should I run in the heat?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "It depends on the combination of temperature and dew point, and on how long you are running. A marathon at 24°C and 75% humidity typically costs 4–6% of finish time, while a 5K in the same conditions costs closer to 1–2% because the race ends before heat fully accumulates.",
+                  },
+                },
+                {
+                  "@type": "Question",
+                  name: "Why does dew point matter more than humidity?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "Relative humidity is meaningless without temperature — 90% humidity at 10°C is a pleasant morning, while 60% at 30°C is brutal. Dew point measures the actual moisture in the air, which sets the ceiling on how fast sweat can evaporate and therefore how well you can cool yourself.",
+                  },
+                },
+                {
+                  "@type": "Question",
+                  name: "How much does altitude slow down a race?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "For a sea-level runner, VO₂max falls roughly 1.8% per 300 m above about 300 m of elevation. At 1,600 m (Denver) that is around an 8% reduction in aerobic capacity, which costs a marathoner several minutes. Living at altitude for two or more weeks recovers part of the deficit but never all of it.",
+                  },
+                },
+                {
+                  "@type": "Question",
+                  name: "Should I adjust my training paces in hot weather?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "Yes. Running your normal easy pace in the heat pushes you into a harder zone than intended, which compromises recovery. Adjust easy and long-run paces the most, since they carry the longest heat exposure, and treat short intervals as effort-based rather than chasing usual splits.",
+                  },
+                },
+                {
+                  "@type": "Question",
+                  name: "Do I get faster in cold weather?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "Slightly, but the benefit is small and plateaus. Most runners perform best somewhere between about 5°C and 12°C. Below freezing, footing, wind chill, and heavier clothing start costing more than the cooling helps, so this calculator does not model cold as a bonus.",
+                  },
+                },
+              ],
+            },
+          ],
+        })}
+      </script>
+    </Helmet>
+  );
+}

--- a/vite-project/src/features/conditions/components/ConditionsVerdict.tsx
+++ b/vite-project/src/features/conditions/components/ConditionsVerdict.tsx
@@ -1,0 +1,274 @@
+/**
+ * ConditionsVerdict — the headline answer.
+ *
+ * The number a runner came for is the adjusted finish time, so it gets the
+ * largest type on the page. Everything else here exists to make that number
+ * trustworthy: what the original goal was, how much of the cost came from heat
+ * versus altitude, and what fitness the adjusted result is actually equivalent
+ * to.
+ */
+
+import { TrendingDown, Flame, Mountain, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatTime, formatPace } from "@/features/vdot-calculator/vdot-math";
+import type { ConditionsResult, PaceUnit } from "../types";
+
+/**
+ * Tailwind can't build class names at runtime, so every risk colour needs a
+ * statically-written entry here.
+ */
+const RISK_STYLES: Record<
+  string,
+  { pill: string; ring: string; bar: string; text: string }
+> = {
+  emerald: {
+    pill: "bg-emerald-100 text-emerald-800 border-emerald-200",
+    ring: "from-emerald-500 to-emerald-600",
+    bar: "bg-emerald-500",
+    text: "text-emerald-700",
+  },
+  lime: {
+    pill: "bg-lime-100 text-lime-800 border-lime-200",
+    ring: "from-lime-500 to-lime-600",
+    bar: "bg-lime-500",
+    text: "text-lime-700",
+  },
+  yellow: {
+    pill: "bg-yellow-100 text-yellow-800 border-yellow-200",
+    ring: "from-yellow-500 to-yellow-600",
+    bar: "bg-yellow-500",
+    text: "text-yellow-700",
+  },
+  orange: {
+    pill: "bg-orange-100 text-orange-800 border-orange-200",
+    ring: "from-orange-500 to-orange-600",
+    bar: "bg-orange-500",
+    text: "text-orange-700",
+  },
+  red: {
+    pill: "bg-red-100 text-red-800 border-red-200",
+    ring: "from-red-500 to-red-600",
+    bar: "bg-red-500",
+    text: "text-red-700",
+  },
+  rose: {
+    pill: "bg-rose-100 text-rose-900 border-rose-300",
+    ring: "from-rose-600 to-rose-700",
+    bar: "bg-rose-600",
+    text: "text-rose-700",
+  },
+};
+
+/** "+2:34" / "—" for a time delta in seconds. */
+function formatDelta(seconds: number): string {
+  if (Math.round(seconds) === 0) return "—";
+  const sign = seconds > 0 ? "+" : "−";
+  return `${sign}${formatTime(Math.abs(seconds))}`;
+}
+
+interface Props {
+  result: ConditionsResult;
+  distanceName: string;
+  paceUnit: PaceUnit;
+  onTogglePaceUnit: () => void;
+}
+
+export function ConditionsVerdict({
+  result,
+  distanceName,
+  paceUnit,
+  onTogglePaceUnit,
+}: Props) {
+  const styles = RISK_STYLES[result.riskColor] ?? RISK_STYLES.yellow;
+  const perKm = paceUnit === "km";
+
+  const goalPace = perKm ? result.goalPacePerKm : result.goalPacePerMile;
+  const adjPace = perKm ? result.adjustedPacePerKm : result.adjustedPacePerMile;
+  const paceCost = perKm ? result.paceCostPerKm : result.paceCostPerMile;
+
+  const heatCost = Math.max(0, result.heatCostSeconds);
+  const altCost = Math.max(0, result.altitudeCostSeconds);
+  const totalCost = heatCost + altCost;
+  // Guard the divide so a perfect-conditions result doesn't produce NaN widths.
+  const heatShare = totalCost > 0 ? (heatCost / totalCost) * 100 : 0;
+  const altShare = totalCost > 0 ? (altCost / totalCost) * 100 : 0;
+
+  const noPenalty = Math.round(result.totalCostSeconds) <= 0;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg border-0 overflow-hidden">
+      {/* Headline */}
+      <div className="p-5 sm:p-7">
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div>
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+              Realistic {distanceName} finish
+            </p>
+            <div className="flex items-baseline gap-3 mt-1 flex-wrap">
+              <span className="text-4xl sm:text-5xl font-black text-gray-900 tabular-nums tracking-tight">
+                {formatTime(result.adjustedTimeSeconds)}
+              </span>
+              {!noPenalty && (
+                <span className={cn("text-lg font-bold tabular-nums", styles.text)}>
+                  {formatDelta(result.totalCostSeconds)}
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-gray-500 mt-1">
+              {noPenalty ? (
+                <>Your goal of {formatTime(result.goalTimeSeconds)} stands.</>
+              ) : (
+                <>
+                  Goal was{" "}
+                  <span className="font-semibold text-gray-700 tabular-nums">
+                    {formatTime(result.goalTimeSeconds)}
+                  </span>{" "}
+                  in perfect conditions
+                </>
+              )}
+            </p>
+          </div>
+
+          <span
+            className={cn(
+              "flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-bold border whitespace-nowrap",
+              styles.pill
+            )}
+          >
+            {result.riskLabel}
+          </span>
+        </div>
+
+        {/* Pace */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-xl bg-slate-50 border border-slate-100 p-3">
+            <p className="text-[11px] font-medium text-gray-400 uppercase tracking-wide">
+              Goal pace
+            </p>
+            <p className="text-lg font-bold text-gray-400 tabular-nums line-through decoration-1">
+              {formatPace(goalPace)}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onTogglePaceUnit}
+            title="Toggle min/km and min/mi"
+            className="text-left rounded-xl bg-emerald-50 border border-emerald-100 p-3 hover:border-emerald-300 transition-colors"
+          >
+            <p className="text-[11px] font-medium text-emerald-600 uppercase tracking-wide">
+              Run this instead · /{paceUnit}
+            </p>
+            <p className="text-lg font-bold text-emerald-800 tabular-nums">
+              {formatPace(adjPace)}
+              {paceCost >= 1 && (
+                <span className="ml-1.5 text-xs font-semibold text-emerald-600">
+                  +{Math.round(paceCost)}s
+                </span>
+              )}
+            </p>
+          </button>
+        </div>
+      </div>
+
+      {/* Cost attribution */}
+      {!noPenalty && (
+        <div className="px-5 sm:px-7 pb-5">
+          <p className="text-[11px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+            Where the time goes
+          </p>
+          <div className="flex h-2.5 rounded-full overflow-hidden bg-gray-100">
+            {heatShare > 0 && (
+              <div
+                className="bg-orange-500"
+                style={{ width: `${heatShare}%` }}
+                title="Heat &amp; humidity"
+              />
+            )}
+            {altShare > 0 && (
+              <div
+                className="bg-violet-500"
+                style={{ width: `${altShare}%` }}
+                title="Altitude"
+              />
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-5 gap-y-1 mt-2">
+            {heatCost >= 1 && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-gray-600">
+                <Flame className="w-3.5 h-3.5 text-orange-500" />
+                Heat &amp; humidity
+                <span className="font-bold tabular-nums text-gray-900">
+                  {formatDelta(heatCost)}
+                </span>
+              </span>
+            )}
+            {altCost >= 1 && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-gray-600">
+                <Mountain className="w-3.5 h-3.5 text-violet-500" />
+                Altitude
+                <span className="font-bold tabular-nums text-gray-900">
+                  {formatDelta(altCost)}
+                </span>
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Secondary metrics */}
+      <div className="grid grid-cols-3 divide-x divide-gray-100 border-t border-gray-100 bg-slate-50/60">
+        <Metric
+          label="Heat stress"
+          value={String(Math.round(result.heatStressSum))}
+          sub="temp + dew pt (°F)"
+        />
+        <Metric
+          label="Effective VDOT"
+          value={result.effectiveVdot.toFixed(1)}
+          sub={
+            result.vdotDrop >= 0.05
+              ? `−${result.vdotDrop.toFixed(1)} from ${result.baselineVdot.toFixed(1)}`
+              : "no change"
+          }
+          icon={result.vdotDrop >= 0.05}
+        />
+        <Metric
+          label="Aerobic capacity"
+          value={`${Math.round(result.altitudeVo2Fraction * 100)}%`}
+          sub="of sea level"
+        />
+      </div>
+
+      {/* Advice */}
+      <div className="flex gap-2.5 p-4 sm:px-7 border-t border-gray-100">
+        <Info className={cn("w-4 h-4 flex-shrink-0 mt-0.5", styles.text)} />
+        <p className="text-sm text-gray-600 leading-relaxed">{result.advice}</p>
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  sub,
+  icon,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  icon?: boolean;
+}) {
+  return (
+    <div className="px-3 py-3 text-center">
+      <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">
+        {label}
+      </p>
+      <p className="text-xl font-bold text-gray-900 tabular-nums mt-0.5 inline-flex items-center gap-1">
+        {icon && <TrendingDown className="w-4 h-4 text-orange-500" />}
+        {value}
+      </p>
+      <p className="text-[11px] text-gray-400 leading-tight">{sub}</p>
+    </div>
+  );
+}

--- a/vite-project/src/features/conditions/components/TemperatureCurveChart.tsx
+++ b/vite-project/src/features/conditions/components/TemperatureCurveChart.tsx
@@ -1,0 +1,165 @@
+/**
+ * TemperatureCurveChart — finish time as a function of temperature, with the
+ * user's own forecast marked on the curve.
+ *
+ * This is the part that changes behaviour. A single adjusted time tells you
+ * what to expect; the curve tells you what to *do* — it's visibly flat below
+ * ~15°C and then bends hard, which is the honest argument for an early start
+ * time or a different goal race.
+ */
+
+import { useMemo } from "react";
+import { Line } from "react-chartjs-2";
+import {
+  Chart,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Filler,
+  type ChartOptions,
+  type TooltipItem,
+} from "chart.js";
+import { formatTime } from "@/features/vdot-calculator/vdot-math";
+import { celsiusToFahrenheit } from "../conditions-math";
+import type { SensitivityPoint } from "../conditions-math";
+import type { TempUnit } from "../types";
+
+Chart.register(LinearScale, PointElement, LineElement, Tooltip, Filler);
+
+interface Props {
+  points: SensitivityPoint[];
+  currentTempC: number;
+  currentTimeSeconds: number;
+  goalTimeSeconds: number;
+  tempUnit: TempUnit;
+}
+
+export function TemperatureCurveChart({
+  points,
+  currentTempC,
+  currentTimeSeconds,
+  goalTimeSeconds,
+  tempUnit,
+}: Props) {
+  const data = useMemo(() => {
+    const toDisplayTemp = (c: number) =>
+      tempUnit === "C" ? c : celsiusToFahrenheit(c);
+
+    const curve = points.map((p) => ({
+      x: toDisplayTemp(p.tempC),
+      y: p.adjustedTimeSeconds,
+    }));
+
+    return {
+      datasets: [
+        {
+          label: "Predicted finish",
+          data: curve,
+          borderColor: "#059669",
+          backgroundColor: "rgba(5, 150, 105, 0.08)",
+          borderWidth: 2.5,
+          pointRadius: 0,
+          pointHoverRadius: 4,
+          pointHoverBackgroundColor: "#059669",
+          fill: true,
+          tension: 0.25,
+        },
+        {
+          // Single-point dataset standing in for an annotation plugin — keeps
+          // the marker on the same scales without adding a dependency.
+          label: "Your forecast",
+          data: [
+            { x: toDisplayTemp(currentTempC), y: currentTimeSeconds },
+          ],
+          borderColor: "#ea580c",
+          backgroundColor: "#ea580c",
+          pointRadius: 6,
+          pointHoverRadius: 8,
+          pointBorderColor: "#fff",
+          pointBorderWidth: 2.5,
+          showLine: false,
+        },
+      ],
+    };
+  }, [points, currentTempC, currentTimeSeconds, tempUnit]);
+
+  const options: ChartOptions<"line"> = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: "nearest", axis: "x", intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title: (items: TooltipItem<"line">[]) =>
+              `${Math.round(items[0].parsed.x)}°${tempUnit}`,
+            label: (item: TooltipItem<"line">) => {
+              const seconds = item.parsed.y;
+              const delta = seconds - goalTimeSeconds;
+              const deltaText =
+                Math.round(delta) > 0 ? ` (+${formatTime(delta)})` : "";
+              return `${formatTime(seconds)}${deltaText}`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          type: "linear",
+          title: {
+            display: true,
+            text: `Temperature (°${tempUnit})`,
+            color: "#9ca3af",
+            font: { size: 11 },
+          },
+          ticks: {
+            color: "#9ca3af",
+            font: { size: 10 },
+            maxTicksLimit: 8,
+            callback: (value) => `${value}°`,
+          },
+          grid: { display: false },
+        },
+        y: {
+          title: { display: false },
+          ticks: {
+            color: "#9ca3af",
+            font: { size: 10 },
+            maxTicksLimit: 5,
+            callback: (value) => formatTime(Number(value)),
+          },
+          grid: { color: "rgba(0,0,0,0.04)" },
+        },
+      },
+    }),
+    [tempUnit, goalTimeSeconds]
+  );
+
+  if (points.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-lg border-0 p-5 sm:p-6">
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-900 uppercase tracking-wide">
+            How much does the weather cost you?
+          </h2>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Finish time across the temperature range, holding your forecast
+            humidity and race elevation fixed.
+          </p>
+        </div>
+        <span className="flex-shrink-0 inline-flex items-center gap-1.5 text-[11px] font-semibold text-orange-600">
+          <span className="w-2.5 h-2.5 rounded-full bg-orange-600 border-2 border-white ring-1 ring-orange-200" />
+          You
+        </span>
+      </div>
+
+      <div className="h-56 sm:h-64 mt-3">
+        <Line data={data} options={options} />
+      </div>
+    </div>
+  );
+}

--- a/vite-project/src/features/conditions/conditions-math.ts
+++ b/vite-project/src/features/conditions/conditions-math.ts
@@ -1,0 +1,466 @@
+/**
+ * Race Day Conditions — Core Math Engine
+ *
+ * Answers two questions a runner actually has on race week:
+ *   1. "It's going to be 28°C and humid — what's my realistic finish time?"
+ *   2. "What pace should I actually run today's workout at?"
+ *
+ * Two independent physiological penalties are modelled and then composed:
+ *
+ *   HEAT   Thermoregulation competes with the working muscles for cardiac
+ *          output, and evaporative cooling fails as the air saturates. The
+ *          practical predictor is the *sum* of air temperature and dew point
+ *          (both °F) — the long-standing rule of thumb in the running
+ *          community, because dew point captures the evaporative ceiling in a
+ *          way relative humidity alone does not (20°C/90% RH and 30°C/40% RH
+ *          are very different runs at the same "warm" description).
+ *
+ *   ALTITUDE  Lower partial pressure of oxygen reduces VO₂max directly. This
+ *          one is modelled at the fitness level rather than the pace level:
+ *          we shrink VDOT and let the existing Daniels engine re-predict the
+ *          race, which is why the altitude penalty automatically grows with
+ *          race distance without any extra rules.
+ *
+ * Both are estimates for a healthy, sea-level-resident runner. They describe
+ * the *typical* response; individual heat tolerance varies a lot.
+ */
+
+import {
+  calculateVdot,
+  predictRaceTime,
+  calculateTrainingZones,
+  velocityToPacePerKm,
+  velocityToPacePerMile,
+  trainingVelocity,
+} from "@/features/vdot-calculator/vdot-math";
+import type {
+  ConditionsInput,
+  ConditionsResult,
+  HeatRiskBand,
+  AdjustedZone,
+} from "./types";
+
+/* ------------------------------------------------------------------ */
+/* Unit helpers                                                        */
+/* ------------------------------------------------------------------ */
+
+export function celsiusToFahrenheit(c: number): number {
+  return c * 1.8 + 32;
+}
+
+export function fahrenheitToCelsius(f: number): number {
+  return (f - 32) / 1.8;
+}
+
+export function metersToFeet(m: number): number {
+  return m * 3.28084;
+}
+
+export function feetToMeters(ft: number): number {
+  return ft / 3.28084;
+}
+
+/* ------------------------------------------------------------------ */
+/* Dew point                                                           */
+/* ------------------------------------------------------------------ */
+
+const MAGNUS_A = 17.625;
+const MAGNUS_B = 243.04;
+
+/**
+ * Dew point from air temperature and relative humidity (Magnus-Tetens).
+ *
+ * @param tempC - Air temperature in °C
+ * @param relativeHumidity - Relative humidity as a percentage (0–100)
+ * @returns Dew point in °C
+ */
+export function dewPointC(tempC: number, relativeHumidity: number): number {
+  // Clamp away from 0% RH: ln(0) is -Infinity, and no real weather report is
+  // truly 0% anyway.
+  const rh = Math.min(100, Math.max(1, relativeHumidity));
+  const alpha =
+    Math.log(rh / 100) + (MAGNUS_A * tempC) / (MAGNUS_B + tempC);
+  return (MAGNUS_B * alpha) / (MAGNUS_A - alpha);
+}
+
+/**
+ * The heat-stress "sum": air temperature + dew point, both in °F.
+ *
+ * Runners use this rather than temperature alone because it collapses the two
+ * things that matter — how hot the air is, and how much evaporative cooling
+ * headroom is left — into one number that maps cleanly onto observed slowdown.
+ */
+export function heatStressSum(tempC: number, relativeHumidity: number): number {
+  return (
+    celsiusToFahrenheit(tempC) +
+    celsiusToFahrenheit(dewPointC(tempC, relativeHumidity))
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Heat penalty                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Slowdown as a fraction of finish time, keyed on the temp+dew-point sum (°F).
+ * Below 100 the sum is not a limiter for a healthy runner, so the penalty is
+ * zero — a cold day is not modelled as a bonus here (see note in the UI copy).
+ *
+ * These anchors are the conventional community bands; intermediate values are
+ * linearly interpolated rather than snapped, so a 1° forecast change moves the
+ * answer smoothly instead of jumping a whole band.
+ */
+const HEAT_ANCHORS: ReadonlyArray<readonly [sum: number, slowdown: number]> = [
+  [100, 0],
+  [110, 0.005],
+  [120, 0.01],
+  [130, 0.02],
+  [140, 0.03],
+  [150, 0.045],
+  [160, 0.06],
+  [170, 0.08],
+  [180, 0.1],
+] as const;
+
+/** Slope of the final segment, reused to extrapolate above the last anchor. */
+const HEAT_TAIL_SLOPE =
+  (HEAT_ANCHORS[HEAT_ANCHORS.length - 1][1] -
+    HEAT_ANCHORS[HEAT_ANCHORS.length - 2][1]) /
+  (HEAT_ANCHORS[HEAT_ANCHORS.length - 1][0] -
+    HEAT_ANCHORS[HEAT_ANCHORS.length - 2][0]);
+
+/**
+ * Base heat slowdown for the reference effort (~1 hour) at a given stress sum.
+ * @returns Fraction of finish time lost, e.g. 0.03 = 3% slower
+ */
+export function baseHeatSlowdown(sum: number): number {
+  const first = HEAT_ANCHORS[0];
+  const last = HEAT_ANCHORS[HEAT_ANCHORS.length - 1];
+
+  if (sum <= first[0]) return 0;
+  if (sum >= last[0]) return last[1] + (sum - last[0]) * HEAT_TAIL_SLOPE;
+
+  for (let i = 1; i < HEAT_ANCHORS.length; i++) {
+    const [hiSum, hiSlow] = HEAT_ANCHORS[i];
+    if (sum <= hiSum) {
+      const [loSum, loSlow] = HEAT_ANCHORS[i - 1];
+      const t = (sum - loSum) / (hiSum - loSum);
+      return loSlow + t * (hiSlow - loSlow);
+    }
+  }
+  return last[1];
+}
+
+const HEAT_REFERENCE_MINUTES = 20;
+
+/**
+ * Heat hurts long races disproportionately: a 5K is over before core
+ * temperature climbs far, while a marathon spends hours accumulating heat the
+ * body cannot shed. This scales the base penalty by race duration, normalised
+ * so that a ~1 hour effort sits at roughly 1.0×.
+ *
+ * @param durationMinutes - Expected race duration under ideal conditions
+ */
+export function durationHeatFactor(durationMinutes: number): number {
+  if (durationMinutes <= HEAT_REFERENCE_MINUTES) return 0.6;
+  const factor =
+    0.6 + 0.37 * Math.log(durationMinutes / HEAT_REFERENCE_MINUTES);
+  return Math.min(1.7, factor);
+}
+
+/* ------------------------------------------------------------------ */
+/* Altitude penalty                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Below this elevation the aerobic cost is not meaningfully different. */
+const ALTITUDE_THRESHOLD_M = 300;
+/** Fraction of VO₂max lost per 300 m above the threshold, acute exposure. */
+const VO2_LOSS_PER_300M = 0.018;
+/** Acclimatisation recovers part of the deficit — never all of it. */
+const ACCLIMATISED_RESIDUAL = 0.6;
+
+/**
+ * Fraction of sea-level VO₂max retained at a given elevation.
+ *
+ * @param altitudeMeters - Elevation of the race
+ * @param acclimatised - True if the runner has lived at altitude 2+ weeks
+ * @returns Multiplier in (0, 1], e.g. 0.93 = 7% of VO₂max lost
+ */
+export function altitudeVo2Fraction(
+  altitudeMeters: number,
+  acclimatised: boolean
+): number {
+  if (altitudeMeters <= ALTITUDE_THRESHOLD_M) return 1;
+  const steps = (altitudeMeters - ALTITUDE_THRESHOLD_M) / 300;
+  const acuteLoss = steps * VO2_LOSS_PER_300M;
+  const loss = acclimatised ? acuteLoss * ACCLIMATISED_RESIDUAL : acuteLoss;
+  // Floor guards against nonsense inputs (Everest-height "races").
+  return Math.max(0.5, 1 - loss);
+}
+
+/* ------------------------------------------------------------------ */
+/* Risk banding                                                        */
+/* ------------------------------------------------------------------ */
+
+interface BandSpec {
+  band: HeatRiskBand;
+  label: string;
+  color: string;
+  advice: string;
+}
+
+const BANDS: ReadonlyArray<readonly [maxSum: number, spec: BandSpec]> = [
+  [
+    100,
+    {
+      band: "ideal",
+      label: "Ideal",
+      color: "emerald",
+      advice:
+        "Prime racing conditions. Run your goal pace as planned — cooling is not a limiter today.",
+    },
+  ],
+  [
+    130,
+    {
+      band: "mild",
+      label: "Mild",
+      color: "lime",
+      advice:
+        "Noticeable but manageable. Drink to thirst, and expect the last third to feel slightly harder than usual.",
+    },
+  ],
+  [
+    150,
+    {
+      band: "moderate",
+      label: "Moderate",
+      color: "yellow",
+      advice:
+        "Start at the adjusted pace, not your goal pace. Take fluid at every station and pour water over your head and forearms.",
+    },
+  ],
+  [
+    170,
+    {
+      band: "hard",
+      label: "Hard",
+      color: "orange",
+      advice:
+        "Race by effort, not by watch. Go out slower than the adjusted pace and reassess at halfway — a positive split here is very costly.",
+    },
+  ],
+  [
+    180,
+    {
+      band: "severe",
+      label: "Severe",
+      color: "red",
+      advice:
+        "Treat time goals as off the table. Prioritise finishing safely: walk aid stations, use ice, and stop if you get chills or stop sweating.",
+    },
+  ],
+];
+
+const DANGEROUS_SPEC: BandSpec = {
+  band: "dangerous",
+  label: "Dangerous",
+  color: "rose",
+  advice:
+    "These conditions carry a real risk of heat illness. Races are often shortened or cancelled at this level — consider not racing, and never push through dizziness, confusion, or chills.",
+};
+
+export function heatRiskBand(sum: number): BandSpec {
+  for (const [maxSum, spec] of BANDS) {
+    if (sum < maxSum) return spec;
+  }
+  return DANGEROUS_SPEC;
+}
+
+/* ------------------------------------------------------------------ */
+/* Composition                                                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Apply race-day conditions to a goal performance.
+ *
+ * Altitude is applied first, at the fitness level: VDOT is scaled by the
+ * retained VO₂max fraction and the race is re-predicted from that. Heat is
+ * then applied as a time penalty on top, because heat degrades the *sustainable
+ * fraction* of a given capacity rather than capacity itself.
+ *
+ * The reported `effectiveVdot` is back-solved from the final adjusted time, so
+ * it reflects both penalties as a single "what fitness would this equate to at
+ * sea level in perfect weather" number.
+ */
+export function calculateConditions(
+  input: ConditionsInput
+): ConditionsResult | null {
+  const { distanceMeters, goalTimeSeconds, tempC, humidity, altitudeMeters } =
+    input;
+
+  if (
+    !isFinite(distanceMeters) ||
+    distanceMeters <= 0 ||
+    !isFinite(goalTimeSeconds) ||
+    goalTimeSeconds <= 0
+  ) {
+    return null;
+  }
+
+  const baselineVdot = calculateVdot(distanceMeters, goalTimeSeconds);
+  if (!isFinite(baselineVdot) || baselineVdot <= 0) return null;
+
+  // --- Altitude: shrink capacity, re-predict the race ---
+  const vo2Fraction = altitudeVo2Fraction(
+    altitudeMeters,
+    input.acclimatised
+  );
+  const altitudeVdot = baselineVdot * vo2Fraction;
+  const afterAltitudeSeconds =
+    vo2Fraction === 1
+      ? goalTimeSeconds
+      : predictRaceTime(altitudeVdot, distanceMeters);
+  const altitudeCostSeconds = afterAltitudeSeconds - goalTimeSeconds;
+
+  // --- Heat: time penalty scaled by how long you're out there ---
+  const sum = heatStressSum(tempC, humidity);
+  const dewPoint = dewPointC(tempC, humidity);
+  // Scale on the altitude-adjusted duration: at altitude you're exposed longer.
+  const heatSlowdown =
+    baseHeatSlowdown(sum) * durationHeatFactor(afterAltitudeSeconds / 60);
+  const adjustedSeconds = afterAltitudeSeconds * (1 + heatSlowdown);
+  const heatCostSeconds = adjustedSeconds - afterAltitudeSeconds;
+
+  // --- Back-solve a single equivalent fitness number ---
+  const effectiveVdot = calculateVdot(distanceMeters, adjustedSeconds);
+
+  const adjustedPacePerKm = (adjustedSeconds / distanceMeters) * 1000;
+  const adjustedPacePerMile = (adjustedSeconds / distanceMeters) * 1609.34;
+  const goalPacePerKm = (goalTimeSeconds / distanceMeters) * 1000;
+  const goalPacePerMile = (goalTimeSeconds / distanceMeters) * 1609.34;
+
+  const spec = heatRiskBand(sum);
+
+  return {
+    baselineVdot,
+    effectiveVdot,
+    vdotDrop: baselineVdot - effectiveVdot,
+
+    goalTimeSeconds,
+    adjustedTimeSeconds: adjustedSeconds,
+    totalCostSeconds: adjustedSeconds - goalTimeSeconds,
+    heatCostSeconds,
+    altitudeCostSeconds,
+
+    goalPacePerKm,
+    goalPacePerMile,
+    adjustedPacePerKm,
+    adjustedPacePerMile,
+    paceCostPerKm: adjustedPacePerKm - goalPacePerKm,
+    paceCostPerMile: adjustedPacePerMile - goalPacePerMile,
+
+    dewPointC: dewPoint,
+    heatStressSum: sum,
+    heatSlowdownFraction: heatSlowdown,
+    altitudeVo2Fraction: vo2Fraction,
+
+    riskBand: spec.band,
+    riskLabel: spec.label,
+    riskColor: spec.color,
+    advice: spec.advice,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Adjusted training paces                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Today's training paces under the given conditions.
+ *
+ * Same principle as the race adjustment, but the heat factor is evaluated at
+ * each zone's own realistic session duration — a 40-minute easy run and a set
+ * of 400m reps do not carry the same heat cost, and collapsing them to one
+ * number is what makes most "hot weather pace" tables feel wrong.
+ */
+export function calculateAdjustedZones(
+  baselineVdot: number,
+  tempC: number,
+  humidity: number,
+  altitudeMeters: number,
+  acclimatised: boolean
+): AdjustedZone[] {
+  const sum = heatStressSum(tempC, humidity);
+  const vo2Fraction = altitudeVo2Fraction(altitudeMeters, acclimatised);
+  const altitudeVdot = baselineVdot * vo2Fraction;
+  const base = baseHeatSlowdown(sum);
+
+  // Representative continuous-effort duration per zone, in minutes. Reps and
+  // intervals are short bouts with recovery, so heat bites far less than it
+  // does during a steady 90-minute long run.
+  const zoneMinutes: Record<string, number> = {
+    Easy: 60,
+    Marathon: 90,
+    Threshold: 25,
+    Interval: 5,
+    Repetition: 2,
+  };
+
+  return calculateTrainingZones(baselineVdot).map((zone) => {
+    const slowdown = base * durationHeatFactor(zoneMinutes[zone.name] ?? 30);
+
+    // Recompute the zone's velocities off the altitude-adjusted VDOT, then
+    // apply the heat time penalty to the resulting pace.
+    const fastVelocity = trainingVelocity(altitudeVdot, zone.intensityRange[1]);
+    const slowVelocity = trainingVelocity(altitudeVdot, zone.intensityRange[0]);
+
+    const adjKmFast = velocityToPacePerKm(fastVelocity) * (1 + slowdown);
+    const adjKmSlow = velocityToPacePerKm(slowVelocity) * (1 + slowdown);
+    const adjMiFast = velocityToPacePerMile(fastVelocity) * (1 + slowdown);
+    const adjMiSlow = velocityToPacePerMile(slowVelocity) * (1 + slowdown);
+
+    return {
+      name: zone.name,
+      shortName: zone.shortName,
+      description: zone.description,
+      color: zone.color,
+      basePacePerKmSeconds: zone.pacePerKmSeconds,
+      basePacePerMileSeconds: zone.pacePerMileSeconds,
+      adjustedPacePerKmSeconds: [adjKmFast, adjKmSlow],
+      adjustedPacePerMileSeconds: [adjMiFast, adjMiSlow],
+      slowdownFraction: slowdown,
+    };
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Sensitivity sweep (for the chart)                                   */
+/* ------------------------------------------------------------------ */
+
+export interface SensitivityPoint {
+  tempC: number;
+  adjustedTimeSeconds: number;
+}
+
+/**
+ * Sweep finish time across a temperature range, holding humidity and altitude
+ * fixed. This is what turns a single number into a decision: seeing the curve
+ * go nearly flat below 15°C and then bend sharply upward tells a runner how
+ * much a 6am start is actually worth.
+ */
+export function temperatureSensitivity(
+  input: ConditionsInput,
+  fromC = -5,
+  toC = 40,
+  stepC = 1
+): SensitivityPoint[] {
+  const points: SensitivityPoint[] = [];
+  for (let t = fromC; t <= toC; t += stepC) {
+    const result = calculateConditions({ ...input, tempC: t });
+    if (result) {
+      points.push({ tempC: t, adjustedTimeSeconds: result.adjustedTimeSeconds });
+    }
+  }
+  return points;
+}

--- a/vite-project/src/features/conditions/hooks/useConditionsCalculator.ts
+++ b/vite-project/src/features/conditions/hooks/useConditionsCalculator.ts
@@ -1,0 +1,254 @@
+/**
+ * useConditionsCalculator — form state + live derivation for the race day
+ * conditions calculator.
+ *
+ * There is deliberately no "Calculate" button: the whole value of this tool is
+ * dragging the temperature and watching the finish time move, so everything
+ * recomputes as you type.
+ */
+
+import { useState, useMemo, useCallback, useEffect } from "react";
+import ReactGA from "react-ga4";
+import {
+  calculateConditions,
+  calculateAdjustedZones,
+  temperatureSensitivity,
+  fahrenheitToCelsius,
+  celsiusToFahrenheit,
+  feetToMeters,
+  metersToFeet,
+} from "../conditions-math";
+import { calculateVdot } from "@/features/vdot-calculator/vdot-math";
+import type {
+  ConditionsFormState,
+  ConditionsInput,
+  PaceUnit,
+  TempUnit,
+  AltitudeUnit,
+} from "../types";
+import { CONDITION_DISTANCES } from "../types";
+
+const STORAGE_KEY = "trainpace_conditions_inputs";
+
+const defaultForm: ConditionsFormState = {
+  distanceMeters: CONDITION_DISTANCES[3].meters, // Half marathon
+  distanceName: CONDITION_DISTANCES[3].name,
+  hours: "1",
+  minutes: "45",
+  seconds: "00",
+  temp: "24",
+  tempUnit: "C",
+  humidity: "70",
+  altitude: "0",
+  altitudeUnit: "m",
+  acclimatised: false,
+};
+
+function loadForm(): ConditionsFormState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultForm;
+    // Spread over the default so a stored payload from an older shape can't
+    // leave a required field undefined.
+    return { ...defaultForm, ...(JSON.parse(raw) as ConditionsFormState) };
+  } catch {
+    return defaultForm;
+  }
+}
+
+function saveForm(form: ConditionsFormState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(form));
+  } catch {
+    // localStorage may be unavailable (private mode, quota)
+  }
+}
+
+function toNumber(value: string, fallback = 0): number {
+  const n = parseFloat(value);
+  return isFinite(n) ? n : fallback;
+}
+
+export function useConditionsCalculator(
+  initial?: Partial<ConditionsFormState>
+) {
+  const [form, setForm] = useState<ConditionsFormState>(() => ({
+    ...loadForm(),
+    ...initial,
+  }));
+  const [paceUnit, setPaceUnit] = useState<PaceUnit>("km");
+
+  useEffect(() => {
+    saveForm(form);
+  }, [form]);
+
+  const goalTimeSeconds = useMemo(() => {
+    const h = toNumber(form.hours);
+    const m = toNumber(form.minutes);
+    const s = toNumber(form.seconds);
+    return h * 3600 + m * 60 + s;
+  }, [form.hours, form.minutes, form.seconds]);
+
+  const tempC = useMemo(
+    () =>
+      form.tempUnit === "C"
+        ? toNumber(form.temp)
+        : fahrenheitToCelsius(toNumber(form.temp)),
+    [form.temp, form.tempUnit]
+  );
+
+  const altitudeMeters = useMemo(
+    () =>
+      form.altitudeUnit === "m"
+        ? toNumber(form.altitude)
+        : feetToMeters(toNumber(form.altitude)),
+    [form.altitude, form.altitudeUnit]
+  );
+
+  const input: ConditionsInput = useMemo(
+    () => ({
+      distanceMeters: form.distanceMeters,
+      goalTimeSeconds,
+      tempC,
+      humidity: Math.min(100, Math.max(0, toNumber(form.humidity))),
+      altitudeMeters,
+      acclimatised: form.acclimatised,
+    }),
+    [
+      form.distanceMeters,
+      form.humidity,
+      form.acclimatised,
+      goalTimeSeconds,
+      tempC,
+      altitudeMeters,
+    ]
+  );
+
+  /**
+   * A goal time has to be at least physically plausible before the Daniels
+   * equations mean anything — a 20-minute marathon produces a VDOT the model
+   * can't invert. Gate on the resulting VDOT rather than on the raw time so
+   * the check scales across distances.
+   */
+  const isValid = useMemo(() => {
+    if (goalTimeSeconds <= 0 || form.distanceMeters <= 0) return false;
+    const vdot = calculateVdot(form.distanceMeters, goalTimeSeconds);
+    return isFinite(vdot) && vdot > 10 && vdot < 100;
+  }, [form.distanceMeters, goalTimeSeconds]);
+
+  const result = useMemo(
+    () => (isValid ? calculateConditions(input) : null),
+    [input, isValid]
+  );
+
+  const adjustedZones = useMemo(() => {
+    if (!result) return [];
+    return calculateAdjustedZones(
+      result.baselineVdot,
+      input.tempC,
+      input.humidity,
+      input.altitudeMeters,
+      input.acclimatised
+    );
+  }, [result, input]);
+
+  const sensitivity = useMemo(
+    () => (isValid ? temperatureSensitivity(input) : []),
+    [input, isValid]
+  );
+
+  /* ---------------- handlers ---------------- */
+
+  const setField = useCallback(
+    <K extends keyof ConditionsFormState>(
+      field: K,
+      value: ConditionsFormState[K]
+    ) => {
+      setForm((prev) => ({ ...prev, [field]: value }));
+    },
+    []
+  );
+
+  const selectDistance = useCallback((meters: number, name: string) => {
+    setForm((prev) => ({
+      ...prev,
+      distanceMeters: meters,
+      distanceName: name,
+    }));
+  }, []);
+
+  const setTimePart = useCallback(
+    (field: "hours" | "minutes" | "seconds", value: string) => {
+      const digits = value.replace(/\D/g, "").slice(0, 2);
+      setForm((prev) => ({ ...prev, [field]: digits }));
+    },
+    []
+  );
+
+  /** Switching units converts the displayed value rather than reinterpreting it. */
+  const toggleTempUnit = useCallback(() => {
+    setForm((prev) => {
+      const next: TempUnit = prev.tempUnit === "C" ? "F" : "C";
+      const current = toNumber(prev.temp);
+      const converted =
+        next === "F" ? celsiusToFahrenheit(current) : fahrenheitToCelsius(current);
+      return { ...prev, tempUnit: next, temp: String(Math.round(converted)) };
+    });
+  }, []);
+
+  const toggleAltitudeUnit = useCallback(() => {
+    setForm((prev) => {
+      const next: AltitudeUnit = prev.altitudeUnit === "m" ? "ft" : "m";
+      const current = toNumber(prev.altitude);
+      const converted =
+        next === "ft" ? metersToFeet(current) : feetToMeters(current);
+      return {
+        ...prev,
+        altitudeUnit: next,
+        altitude: String(Math.round(converted)),
+      };
+    });
+  }, []);
+
+  const applyPreset = useCallback(
+    (presetTempC: number, humidity: number, label: string) => {
+      setForm((prev) => ({
+        ...prev,
+        temp: String(
+          Math.round(
+            prev.tempUnit === "C" ? presetTempC : celsiusToFahrenheit(presetTempC)
+          )
+        ),
+        humidity: String(humidity),
+      }));
+      ReactGA.event({
+        category: "Conditions Calculator",
+        action: "Applied preset",
+        label,
+      });
+    },
+    []
+  );
+
+  const togglePaceUnit = useCallback(() => {
+    setPaceUnit((prev) => (prev === "km" ? "mi" : "km"));
+  }, []);
+
+  return {
+    form,
+    paceUnit,
+    goalTimeSeconds,
+    input,
+    isValid,
+    result,
+    adjustedZones,
+    sensitivity,
+    setField,
+    selectDistance,
+    setTimePart,
+    toggleTempUnit,
+    toggleAltitudeUnit,
+    applyPreset,
+    togglePaceUnit,
+  };
+}

--- a/vite-project/src/features/conditions/index.ts
+++ b/vite-project/src/features/conditions/index.ts
@@ -1,0 +1,29 @@
+export { ConditionsCalculator } from "./components/ConditionsCalculator";
+export { useConditionsCalculator } from "./hooks/useConditionsCalculator";
+export {
+  calculateConditions,
+  calculateAdjustedZones,
+  temperatureSensitivity,
+  heatStressSum,
+  heatRiskBand,
+  dewPointC,
+  altitudeVo2Fraction,
+  baseHeatSlowdown,
+  durationHeatFactor,
+  celsiusToFahrenheit,
+  fahrenheitToCelsius,
+  metersToFeet,
+  feetToMeters,
+} from "./conditions-math";
+export type { SensitivityPoint } from "./conditions-math";
+export type {
+  ConditionsInput,
+  ConditionsResult,
+  ConditionsFormState,
+  AdjustedZone,
+  HeatRiskBand,
+  TempUnit,
+  AltitudeUnit,
+  PaceUnit,
+} from "./types";
+export { CONDITION_DISTANCES, CONDITION_PRESETS } from "./types";

--- a/vite-project/src/features/conditions/types.ts
+++ b/vite-project/src/features/conditions/types.ts
@@ -1,0 +1,103 @@
+/**
+ * Race Day Conditions — Types & Constants
+ */
+
+export type TempUnit = "C" | "F";
+export type AltitudeUnit = "m" | "ft";
+export type PaceUnit = "km" | "mi";
+
+export type HeatRiskBand =
+  | "ideal"
+  | "mild"
+  | "moderate"
+  | "hard"
+  | "severe"
+  | "dangerous";
+
+/** Everything the engine needs, already normalised to metric. */
+export interface ConditionsInput {
+  distanceMeters: number;
+  goalTimeSeconds: number;
+  tempC: number;
+  /** Relative humidity, 0–100 */
+  humidity: number;
+  altitudeMeters: number;
+  acclimatised: boolean;
+}
+
+/** Raw form state — strings, because these are controlled text inputs. */
+export interface ConditionsFormState {
+  distanceMeters: number;
+  distanceName: string;
+  hours: string;
+  minutes: string;
+  seconds: string;
+  temp: string;
+  tempUnit: TempUnit;
+  humidity: string;
+  altitude: string;
+  altitudeUnit: AltitudeUnit;
+  acclimatised: boolean;
+}
+
+export interface ConditionsResult {
+  baselineVdot: number;
+  effectiveVdot: number;
+  vdotDrop: number;
+
+  goalTimeSeconds: number;
+  adjustedTimeSeconds: number;
+  totalCostSeconds: number;
+  heatCostSeconds: number;
+  altitudeCostSeconds: number;
+
+  goalPacePerKm: number;
+  goalPacePerMile: number;
+  adjustedPacePerKm: number;
+  adjustedPacePerMile: number;
+  paceCostPerKm: number;
+  paceCostPerMile: number;
+
+  dewPointC: number;
+  heatStressSum: number;
+  heatSlowdownFraction: number;
+  altitudeVo2Fraction: number;
+
+  riskBand: HeatRiskBand;
+  riskLabel: string;
+  riskColor: string;
+  advice: string;
+}
+
+export interface AdjustedZone {
+  name: string;
+  shortName: string;
+  description: string;
+  color: string;
+  basePacePerKmSeconds: [number, number];
+  basePacePerMileSeconds: [number, number];
+  adjustedPacePerKmSeconds: [number, number];
+  adjustedPacePerMileSeconds: [number, number];
+  slowdownFraction: number;
+}
+
+/** Race distances offered by the conditions calculator. */
+export const CONDITION_DISTANCES = [
+  { name: "5K", meters: 5000 },
+  { name: "10K", meters: 10000 },
+  { name: "15K", meters: 15000 },
+  { name: "Half Marathon", meters: 21097.5 },
+  { name: "Marathon", meters: 42195 },
+] as const;
+
+/**
+ * One-tap presets for the conditions most people are actually asking about.
+ * `humidity` is relative humidity in %.
+ */
+export const CONDITION_PRESETS = [
+  { label: "Crisp autumn", tempC: 8, humidity: 65 },
+  { label: "Mild & dry", tempC: 15, humidity: 45 },
+  { label: "Warm & humid", tempC: 24, humidity: 75 },
+  { label: "Hot summer", tempC: 30, humidity: 60 },
+  { label: "Tropical", tempC: 28, humidity: 90 },
+] as const;

--- a/vite-project/src/features/conditions/utils.ts
+++ b/vite-project/src/features/conditions/utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Display helpers for the race day conditions feature.
+ */
+
+import { celsiusToFahrenheit, dewPointC } from "./conditions-math";
+import type { TempUnit } from "./types";
+
+/** Dew point rendered in whichever unit the user is currently working in. */
+export function formatDewPoint(
+  tempC: number,
+  humidity: number,
+  unit: TempUnit
+): string {
+  const dp = dewPointC(tempC, humidity);
+  const value = unit === "C" ? dp : celsiusToFahrenheit(dp);
+  return `${Math.round(value)}°${unit}`;
+}

--- a/vite-project/src/pages/ConditionsCalculatorPage.tsx
+++ b/vite-project/src/pages/ConditionsCalculatorPage.tsx
@@ -1,0 +1,41 @@
+import { useSearchParams } from "react-router-dom";
+import { ConditionsCalculator } from "@/features/conditions";
+import { CONDITION_DISTANCES } from "@/features/conditions";
+import type { ConditionsFormState } from "@/features/conditions";
+
+/**
+ * Accepts the same `?d=<meters>&t=<seconds>` share params the VDOT calculator
+ * emits, so a runner can go straight from "here's my fitness" to "here's what
+ * race day will actually look like" without retyping anything.
+ */
+export default function ConditionsCalculatorPage() {
+  const [searchParams] = useSearchParams();
+
+  const initialForm = (() => {
+    const dParam = searchParams.get("d");
+    const tParam = searchParams.get("t");
+    if (!dParam || !tParam) return undefined;
+
+    const meters = parseFloat(dParam);
+    const totalSec = parseInt(tParam, 10);
+    if (!isFinite(meters) || meters <= 0) return undefined;
+    if (!isFinite(totalSec) || totalSec <= 0) return undefined;
+
+    const match = CONDITION_DISTANCES.find(
+      (d) => Math.abs(d.meters - meters) < 1
+    );
+    // Distances outside this tool's list (800m, mile…) have no sensible entry
+    // here — fall back to the stored form rather than inventing a race.
+    if (!match) return undefined;
+
+    return {
+      distanceMeters: match.meters,
+      distanceName: match.name,
+      hours: String(Math.floor(totalSec / 3600)),
+      minutes: String(Math.floor((totalSec % 3600) / 60)),
+      seconds: String(totalSec % 60),
+    } satisfies Partial<ConditionsFormState>;
+  })();
+
+  return <ConditionsCalculator initialForm={initialForm} />;
+}

--- a/vite-project/vite.config.ts
+++ b/vite-project/vite.config.ts
@@ -14,6 +14,7 @@ const prerenderedRoutes = [
   "/",
   "/calculator",
   "/vdot",
+  "/conditions",
   "/fuel",
   "/plan",
   "/elevationfinder",


### PR DESCRIPTION
Adds `/conditions`, a tool that answers the two questions runners actually have on race week:

1. "It's going to be 28°C and humid — what's my realistic finish time?"
2. "What pace should I run today's workout at?"

There was no weather-aware tool in the app — no mention of heat, humidity, dew point, or altitude anywhere in the codebase — so this fills a real gap rather than restating what the pace/VDOT calculators already do. It builds on the existing Daniels engine instead of duplicating it.

## The model

Two penalties, modelled independently and then composed.

**Heat** keys on the sum of air temperature and dew point (°F) rather than on temperature or relative humidity alone. Dew point is what caps evaporative cooling, so 20°C/90% RH and 30°C/40% RH are very different runs despite both reading as "warm". The penalty is then scaled by race duration — at 24°C/75% a 5K costs ~2% and a marathon ~4.8%. Most hot-weather pace tables apply one flat percentage across all distances, which is why they tend to feel wrong to experienced runners.

**Altitude** is applied at the fitness level instead of the pace level: VDOT is scaled by the retained VO₂max fraction (~1.8% lost per 300 m above 300 m, partially recovered when acclimatised) and the race is re-predicted through the existing engine. The altitude cost then grows with race distance on its own, with no distance-specific rules.

The reported effective VDOT is back-solved from the final adjusted time, giving a single "what would this equate to at sea level in perfect weather" number.

## What the page shows

- Adjusted finish time and race pace, with the cost split between heat and altitude
- Re-targeted paces for all five Daniels zones, each evaluated at its own realistic session duration — a 90-minute long run and a set of 400m reps are not equally exposed to heat
- A temperature sensitivity curve with the user's forecast marked, visibly flat below ~15°C and then bending hard, which is the honest argument for an early start time
- A risk band with practical guidance, escalating to an explicit "don't race this" at dangerous heat-stress levels

Cold is deliberately **not** modelled as a bonus; the FAQ says so rather than leaving it unexplained.

## Notable changes outside the feature

- `Slider` gains an optional `thumbLabel`. The Radix thumb is the element that receives focus and carries `role="slider"`, so an `aria-label` on the root left it announced as an unnamed control. The shared component is only consumed by this new code today, and the prop is optional and additive.
- Route, side nav, prerender list, and sitemap wired up. The page accepts the same `?d=&t=` share params the VDOT calculator emits, so you can go from "here's my fitness" to "here's what race day looks like" without retyping.

## Verification

Numbers were checked, not just the build:

- Magnus dew points exact — 30°C/50% → 18.4°C, 25°C/100% → 25.0°C
- Altitude retention 92.2% at 1600 m, matching published acute-exposure figures
- Distance scaling reads 5K +2.0% → marathon +4.8% at 24°C/75%, in line with observed marathon heat data
- `tsc` clean; ESLint 0 errors and **0 new warnings**; production build passes; `/conditions` prerenders into its own 35 kB chunk
- Browser pass at 1280px and 390px: sliders, altitude input, and presets all drive live recalculation, no console errors, no horizontal overflow

The browser pass caught two bugs static checks would have missed: the global `#root { text-align: center }` from the Vite template was centering copy meant to be left-aligned, and the mobile stack buried the answer below the training-paces table. Both fixed.

## Notes for review

- The heat bands are the conventional community anchors with linear interpolation between them, so a 1° forecast change moves the answer smoothly instead of jumping a whole band. Worth a look if you'd tune the numbers differently.
- Altitude at 1600 m unacclimatised comes out at ~7% for a marathon, which is toward the higher end of the plausible range for a sea-level runner. The acclimatised figure (~4%) lines up well with typical Denver-resident expectations.
- There are no unit tests in this repo, so the math was verified via a throwaway harness rather than committed tests. Happy to add a test setup if you'd like this math pinned down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WER1sSjDfXQunuP45nVShs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WER1sSjDfXQunuP45nVShs)_