### PR TITLE
fix(landing): typography fixes across the landing page and feature shots

### DIFF
--- a/.claude/skills/verify-in-browser/SKILL.md
+++ b/.claude/skills/verify-in-browser/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: verify-in-browser
+description: Drive TrainPace in a real browser to verify a visual change — fonts, layout, animations, tooltips, anything you cannot confirm by reading CSS. Use when a change is visual, when a claim needs a screenshot or a measurement to back it, or when a bug report is vague ("the font is bad", "it looks off") and you need to find out what is actually rendering. Covers the sandbox-specific Playwright setup and the measurement traps that produce confident wrong answers.
+---
+
+# Verifying visual changes in a browser
+
+There are no unit tests here. For anything visual, the browser *is* the test. Reading the CSS is not verification — several defects in this codebase were invisible in source and obvious in a screenshot.
+
+## Working launch recipe
+
+Three things in this sandbox will each silently give you a wrong answer. All three are already handled below; copy this.
+
+```js
+import { chromium } from "playwright";
+import { execFileSync } from "node:child_process";
+
+const UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+const curlBytes = (url) =>
+  execFileSync("curl", ["-sS", "--compressed", "-A", UA, "-H", "Accept: */*", url],
+    { maxBuffer: 64 * 1024 * 1024, encoding: "buffer" });
+
+// 1. The project pins a newer Playwright than the installed browsers.
+//    Without executablePath you get "Executable doesn't exist at .../chromium_headless_shell-1208".
+const browser = await chromium.launch({ executablePath: "/opt/pw-browsers/chromium" });
+
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 2 });
+
+// 2. Chromium cannot reach fonts.googleapis.com through the agent proxy
+//    (ERR_CONNECTION_RESET). Node's curl can. Without this the page renders
+//    entirely in fallback fonts and you measure the sandbox, not the app.
+await ctx.route(/fonts\.(googleapis|gstatic)\.com/, async (route) => {
+  const url = route.request().url();
+  await route.fulfill({
+    status: 200,
+    contentType: url.includes("googleapis.com") ? "text/css; charset=utf-8" : "font/woff2",
+    body: curlBytes(url),
+  });
+});
+
+const page = await ctx.newPage();
+await page.goto("http://localhost:5173/", { waitUntil: "networkidle" });
+await page.evaluate(() => document.fonts.ready);
+```
+
+Run it from the scratchpad with the project's modules reachable:
+
+```bash
+ln -sfn /home/user/trainpace/vite-project/node_modules node_modules
+# 3. Playwright forces --proxy-bypass-list=<-loopback>, so localhost:5173 gets
+#    routed through the agent proxy, which only accepts CONNECT. The page then
+#    "loads" as a proxy error page. This env var restores the loopback bypass.
+PLAYWRIGHT_DISABLE_FORCED_CHROMIUM_PROXIED_LOOPBACK=1 node script.mjs
+```
+
+The dev server needs `vite-project/.env` to exist. Dummy Firebase values are fine for anything that is not auth or maps; `.env` is gitignored.
+
+## Traps that produce confident wrong answers
+
+**`document.fonts.check()` does not tell you a face is available.** It reports whether the string *can be rendered*, and fallback counts as yes. It returned `true` for `800 16px 'Space Grotesk'` (a weight that does not exist) and for `italic 400 16px 'DM Sans'` (a face that was not loaded) — and kept returning `true` on a page that had failed to load entirely. It is not a probe. Measure metrics instead:
+
+```js
+const m = (font, text = "Handgloves 2:06") => {
+  const c = document.createElement("canvas").getContext("2d");
+  c.font = font;
+  return c.measureText(text).width;
+};
+// A family that is not applied measures identically to a bogus family.
+const isFallback = Math.abs(m("400 40px 'DM Sans'") - m("400 40px 'NoSuchFontXYZ'")) < 0.01;
+// An italic that is not real measures identically to its upright.
+const italicIsFake = Math.abs(m("italic 400 40px 'DM Sans'") - m("400 40px 'DM Sans'")) < 0.01;
+// tabular-nums only holds if the family has a tnum table.
+const isTabular = Math.abs(widthOf("1111111111", { tnum: true }) - widthOf("0888888888", { tnum: true })) < 0.5;
+```
+
+**Print a content fingerprint next to every measurement.** Dump the element's text alongside its computed styles. This is what caught the proxy error page — the "body" being measured had text `"agent-proxy relay: this proxy only accepts…"` in Times New Roman. Without the text in the output, those computed styles look like a plausible finding about the app.
+
+**Assert the webfonts actually loaded before judging typography.** `[...document.fonts]` empty means nothing loaded and every conclusion about type is about the fallback stack. Check it explicitly rather than assuming the route worked.
+
+**Check your selector matches the element you think it does, and that separate cases are separate elements.** `section .italic` was meant to grab a testimonial and grabbed the founder quote instead, because `#story` is a `<section>` — so two "different" before/after screenshots were the same element, and a claim of covering both cases rested on one. Log `await locator.count()` and the matched text, and if two shots should differ, diff them.
+
+## Measure the defect, do not eyeball it
+
+Screenshots show you *that* something is wrong; a sweep tells you *where* and *how much*, and gives you a pass condition afterwards. For the elevation tooltip, stepping the cursor across the profile and recording the tooltip box against the stage on all four edges turned up a second clipped edge that was never visible in a static screenshot, and confirmed vertical placement needed no change at all:
+
+```js
+for (let i = 0; i <= STEPS; i++) {
+  await page.mouse.move(box.x + (box.width * i) / STEPS, box.y + box.height / 2);
+  const m = await page.evaluate(() => {
+    const t = document.querySelector(".el-tip").getBoundingClientRect();
+    const s = document.querySelector(".stage").getBoundingClientRect();
+    return { left: s.left - t.left, right: t.right - s.right, top: s.top - t.top, bottom: t.bottom - s.bottom };
+  });
+  // >0 on any edge means clipped
+}
+```
+
+Re-run the same sweep after the fix and report the numbers. Test at more than one viewport — 1440 and 900 exercised different clamp behaviour.
+
+## Before claiming it works
+
+- `npm run build` and `npm run lint` from `vite-project/` (lint has ~96 pre-existing warnings; the bar is 0 **errors** and nothing new in the files you touched).
+- Confirm prerendered output where relevant — `<head>` changes need to survive into `dist/**/index.html`, all ~245 of them, not just `dist/index.html`.
+- Only claim what you measured. If a screenshot did not capture a case, say so rather than letting it stand in.
+
+## Cleanup
+
+Kill the dev server by task ID rather than `pkill -f vite` — that pattern matches the shell running it and returns exit 143/144 while looking like a failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,19 @@ Guidelines:
 - Reserve `opus` for tasks where a wrong answer is expensive (data model changes, Firestore rules, SEO system changes).
 - Prefer the alias (`opus`/`sonnet`/`haiku`) in agent frontmatter so definitions track the latest model automatically.
 
+## Typography
+
+Two webfonts, loaded from Google Fonts in `vite-project/index.html`: **DM Sans** (body, Tailwind `font-sans`) and **Space Grotesk** (headings, Tailwind `font-display`, plus an `h1`–`h6` rule in `index.css`'s `@layer base`).
+
+`:root` in `index.css` sets `font-synthesis: none`. That is deliberate — it avoids ugly faux-bold and faux-oblique — but it means **any face missing from the font URL fails silently rather than being faked**. Adding a weight or style to markup is not enough; it has to be in the request too. Known consequences:
+
+- **Space Grotesk stops at 700.** Google Fonts returns HTTP 400 for a request at 800. `font-extrabold` or `font-black` on a heading silently renders as 700 — pick `font-bold` instead, or switch the element to a family that goes heavier.
+- **Italics need the `1,...` axis** on DM Sans (`ital,opsz,wght@0,...;1,...`). Drop it and every `italic` element renders upright, with no error anywhere.
+- **Space Grotesk has a `tnum` table; DM Sans does not.** So `font-variant-numeric: tabular-nums` works on Space Grotesk and is a no-op on DM Sans. Any column of numbers, and anything that animates through digits, must use Space Grotesk or it will jitter.
+- **Always give a webfont a fallback stack.** A bare `font-family: "Space Grotesk"` falls back to the browser default *serif* when the font fails to load, which looks nothing like the design. In `feature-shots.css` use the `--display` / `--mono` custom properties rather than naming families inline.
+
+Verify font changes by measuring rendered metrics in a browser, not by reading the CSS — see the `verify-in-browser` skill. `document.fonts.check()` in particular does **not** answer "is this face available".
+
 ## Gotchas
 
 - `console.*` calls are stripped in production builds (esbuild config in `vite.config.ts`).

--- a/vite-project/index.html
+++ b/vite-project/index.html
@@ -12,11 +12,13 @@
     <meta name="apple-mobile-web-app-title" content="Train Pace" />
     <link rel="manifest" href="/site.webmanifest" />
 
-    <!-- Display / brand fonts for animated feature shots -->
+    <!-- Brand fonts: DM Sans (body) + Space Grotesk (headings).
+         The DM Sans `1,...` axis loads the real italic face — `font-synthesis: none`
+         in index.css means dropping it leaves italic text rendering upright. -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400..700;1,9..40,400..700&family=Space+Grotesk:wght@400..700&display=swap"
       rel="stylesheet"
     />
 

--- a/vite-project/src/components/feature-shots/FeatureShots.tsx
+++ b/vite-project/src/components/feature-shots/FeatureShots.tsx
@@ -211,6 +211,22 @@ function yAt(xVB: number) {
 }
 const ftAt = (y: number) => Math.round((200 - y) * 2.4 + 30);
 
+const TIP_EDGE_GAP = 10;
+
+// Keep a tooltip centred at `xPx` (in .el-chartwrap coordinates) fully inside
+// the surrounding .stage, which is overflow:hidden. Falls back to centring when
+// the stage is narrower than the tooltip.
+function clampTipX(xPx: number, tipW: number, wrap: HTMLElement) {
+  const stage = wrap.closest(".stage");
+  if (!stage) return xPx;
+  const wrapRect = wrap.getBoundingClientRect();
+  const stageRect = stage.getBoundingClientRect();
+  const half = tipW / 2 + TIP_EDGE_GAP;
+  const min = stageRect.left - wrapRect.left + half;
+  const max = stageRect.right - wrapRect.left - half;
+  return min > max ? (min + max) / 2 : Math.min(Math.max(xPx, min), max);
+}
+
 export function ElevationShot() {
   const { ref, inView } = useInView<HTMLDivElement>();
   const pathRef = useRef<SVGPathElement>(null);
@@ -251,7 +267,10 @@ export function ElevationShot() {
       "</b> ft</span><span>grade <b>" +
       gtxt +
       "</b></span></div>";
-    tip.style.left = xPx + "px";
+    // The tip is centred on the cursor, so near either end of the profile its
+    // outer half runs past the stage, which clips it. Slide it back inside —
+    // there's no arrow tying it to the cursor, so the shift reads as nothing.
+    tip.style.left = clampTipX(xPx, tip.offsetWidth, wrap) + "px";
     tip.style.top = yPx + "px";
     tip.classList.add("show");
   }, []);

--- a/vite-project/src/components/feature-shots/feature-shots.css
+++ b/vite-project/src/components/feature-shots/feature-shots.css
@@ -34,19 +34,20 @@
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
   --spring: cubic-bezier(0.34, 1.4, 0.5, 1);
   --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  --display: "Space Grotesk", system-ui, sans-serif;
   --sh-sm: 0 1px 2px color-mix(in oklch, var(--ink) 6%, transparent);
   --sh-md: 0 1px 2px color-mix(in oklch, var(--ink) 5%, transparent),
     0 16px 34px -20px color-mix(in oklch, var(--ink) 30%, transparent);
 
   color: var(--ink);
-  font-family: "DM Sans", sans-serif;
+  font-family: "DM Sans", system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 .tpfs h1,
 .tpfs h2,
 .tpfs h3 {
-  font-family: "Space Grotesk", sans-serif;
+  font-family: var(--display);
   letter-spacing: -0.025em;
 }
 
@@ -106,7 +107,7 @@
   font-variant-numeric: tabular-nums;
 }
 .tpfs .numeral {
-  font-family: "Space Grotesk";
+  font-family: var(--display);
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.03em;
 }
@@ -302,7 +303,7 @@
   justify-content: center;
 }
 .tpfs .vd-center .score {
-  font-family: "Space Grotesk";
+  font-family: var(--display);
   font-weight: 700;
   font-size: 3.4rem;
   line-height: 0.9;
@@ -337,7 +338,7 @@
   background: var(--accent);
 }
 .tpfs .vd-title {
-  font-family: "Space Grotesk";
+  font-family: var(--display);
   font-weight: 600;
   font-size: 1.02rem;
   margin-bottom: 8px;
@@ -409,7 +410,7 @@
   flex-wrap: wrap;
 }
 .tpfs .el-name {
-  font-family: "Space Grotesk";
+  font-family: var(--display);
   font-weight: 600;
   font-size: 1.02rem;
 }
@@ -560,7 +561,7 @@
   color: var(--ink-4);
 }
 .tpfs .el-stat .v {
-  font-family: "Space Grotesk";
+  font-family: var(--display);
   font-weight: 700;
   font-size: 1.5rem;
   margin-top: 3px;
@@ -602,7 +603,7 @@
   gap: 8px;
 }
 .tpfs .fp-num .n {
-  font-family: "Space Grotesk";
+  font-family: var(--display);
   font-weight: 700;
   font-size: 3.2rem;
   line-height: 0.9;
@@ -1011,7 +1012,7 @@
 }
 .tpfs .ac-stat b {
   display: block;
-  font-family: "Space Grotesk", sans-serif;
+  font-family: var(--display);
   font-size: 1rem;
   color: var(--ink);
   letter-spacing: -0.02em;
@@ -1068,7 +1069,7 @@
   flex-wrap: wrap;
 }
 .tpfs .tp-title {
-  font-family: "Space Grotesk";
+  font-family: var(--display);
   font-weight: 600;
   font-size: 1.05rem;
 }

--- a/vite-project/src/components/feature-shots/feature-shots.css
+++ b/vite-project/src/components/feature-shots/feature-shots.css
@@ -33,7 +33,12 @@
 
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
   --spring: cubic-bezier(0.34, 1.4, 0.5, 1);
-  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  /* Reserved for genuinely code-like text (tool names, server handles in the
+     agent shot). Numeric readouts use --display + tabular-nums instead: the
+     old stack resolved to the generic monospace off macOS, which reads as a
+     third typeface and runs wide enough to truncate the plan cards. */
+  --mono: ui-monospace, "SF Mono", Menlo, "Cascadia Mono", "Segoe UI Mono",
+    Consolas, "Roboto Mono", "JetBrains Mono", "DejaVu Sans Mono", monospace;
   --display: "Space Grotesk", system-ui, sans-serif;
   --sh-sm: 0 1px 2px color-mix(in oklch, var(--ink) 6%, transparent);
   --sh-md: 0 1px 2px color-mix(in oklch, var(--ink) 5%, transparent),
@@ -103,7 +108,7 @@
   color: var(--accent-deep);
 }
 .tpfs .mono {
-  font-family: var(--mono);
+  font-family: var(--display);
   font-variant-numeric: tabular-nums;
 }
 .tpfs .numeral {
@@ -202,7 +207,8 @@
   transform: scale(1.3);
 }
 .tpfs .pl-pace {
-  font-family: var(--mono);
+  font-family: var(--display);
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
   font-size: 0.94rem;
   color: var(--ink);
@@ -386,7 +392,8 @@
   white-space: nowrap;
 }
 .tpfs .vd-pred .t {
-  font-family: var(--mono);
+  font-family: var(--display);
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
   font-size: 1rem;
   color: var(--ink);
@@ -523,7 +530,8 @@
   opacity: 1;
 }
 .tpfs .el-tip .mi {
-  font-family: var(--mono);
+  font-family: var(--display);
+  font-variant-numeric: tabular-nums;
   font-weight: 600;
 }
 .tpfs .el-tip .row {
@@ -982,7 +990,7 @@
   }
 }
 .tpfs .ac-zrow .v {
-  font-family: var(--mono);
+  font-family: var(--display);
   font-variant-numeric: tabular-nums;
   font-size: 0.72rem;
   color: var(--ink);
@@ -1143,7 +1151,8 @@
 .tpfs .tp-phase-meta .wk {
   font-size: 0.64rem;
   color: var(--ink-4);
-  font-family: var(--mono);
+  font-family: var(--display);
+  font-variant-numeric: tabular-nums;
 }
 @container stage (min-width: 640px) {
   .tpfs .tp-phase-meta .name {
@@ -1215,7 +1224,8 @@
   font-size: 0.7rem;
   color: var(--ink-3);
   margin-top: 3px;
-  font-family: var(--mono);
+  font-family: var(--display);
+  font-variant-numeric: tabular-nums;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/vite-project/src/components/layout/Landing.tsx
+++ b/vite-project/src/components/layout/Landing.tsx
@@ -112,7 +112,9 @@ const Hero = () => {
                 Made for runners by a runner
               </span>
             </div>
-            <h1 className="text-4xl lg:text-6xl font-extrabold text-slate-900 tracking-tight leading-[1.1] mb-6">
+            {/* font-bold, not extrabold: Space Grotesk tops out at 700 and
+                font-synthesis is off, so 800 silently renders as 700 anyway. */}
+            <h1 className="text-4xl lg:text-6xl font-bold text-slate-900 tracking-tight leading-[1.1] mb-6">
               Train Smarter. <br />
               <span className="text-emerald-600">Race Faster.</span>
             </h1>


### PR DESCRIPTION
Three typography defects on the landing page, plus a clipping bug found while verifying them. Each is verified in Chromium rather than reasoned about — details below.

## 1. Italic text rendered upright

The Google Fonts request asked only for the upright axis of DM Sans (`ital,opsz,wght@0,...` — the leading `0` means upright only), and `:root` in `src/index.css` sets `font-synthesis: none`. No italic face plus no synthesis means the browser silently renders italics as regular upright text.

Affected the founder pull-quote in the story section and the three use-case testimonial quotes.

Fixed by adding the `1,...` italic axis. DM Sans ships a real variable italic covering weights 400–700, so these are true italics, not a synthesised slant. Also collapsed the discrete weight lists to `400..700` ranges — both families are variable fonts, so this serves the same files while making intermediate weights available.

## 2. Feature-shot numerals fell back to the generic monospace

The animated shots routed every numeric readout through `--mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace`. Outside macOS none of those resolve, so pace times, race predictions, elevation figures and plan details rendered in the *generic* monospace — DejaVu Sans Mono on Linux, Courier New on Windows. That reads as a third typeface next to DM Sans and Space Grotesk.

It also cost information: the fallback is wide enough to overrun `.tp-day-detail`'s ellipsis clamp, so the training-plan cards showed `5 mi · 8:42/…` instead of `5 mi · 8:42/mi`.

Switched the readouts to Space Grotesk with tabular figures. Space Grotesk carries a real `tnum` table — verified in Chromium, `tabular-nums` holds `1111111111` and `0888888888` to the same width at 400/600/700 — so digits stay column-aligned through the count-up animations, which was the actual reason to reach for a monospace. The large `44:30` and `49.8` numerals already used exactly this treatment, so the small ones now match them.

Worth knowing for future work: **DM Sans has no `tnum`**, so `font-variant-numeric: tabular-nums` is a no-op on it and columns would jitter mid-animation. Anything numeric in these shots needs Space Grotesk.

Switched: `.mono`, `.pl-pace`, `.vd-pred .t`, `.el-tip .mi`, `.ac-zrow .v`, `.tp-phase-meta .wk`, `.tp-day-detail`.

`--mono` is kept for the genuinely code-like text in the agent chat shot (tool names, the server handle), matching the `api.trainpace.com/api/mcp` snippet on the landing itself. Its stack now picks up Cascadia Mono, Segoe UI Mono, Consolas, Roboto Mono and DejaVu Sans Mono so those chips land on a real UI monospace off macOS.

Separately, `feature-shots.css` declared `font-family: "Space Grotesk"` with **no fallback** in seven places — whenever the webfont failed to load, those numerals and titles dropped to the browser default *serif*. They now go through a `--display` custom property carrying `system-ui, sans-serif`, mirroring how `--mono` was already handled.

## 3. Hero `<h1>` requested an unavailable weight

The hero asked for `font-extrabold` (800), but Space Grotesk's variable range stops at 700 — Google Fonts returns HTTP 400 for a request at 800 — so with synthesis disabled it was already rendering at 700. Changed to `font-bold` so the markup matches what ships. No visual change.

## 4. Elevation tooltip clipped at the card edges

Found while verifying the above. The scrub tooltip is centred on the cursor via `translate(-50%, -130%)`, and `.stage` is `overflow: hidden`, so at either end of the profile its outer half fell outside the card.

Swept the cursor across the full profile at 1440px and 900px, measuring the tooltip box against the stage on all four edges:

| Position | 1440px | 900px |
|---|---|---|
| Mile 0.0 (left) | ~30px clipped | ~22px clipped |
| Mile 26.2 (right) | ~32px clipped | ~24px clipped |
| Vertical | clear | clear |

The right-edge case is what the shot settles on, since the auto-play demo eases to the end and stops there. The left-edge case is the same bug at the opposite end.

Added a `clampTipX` helper holding the tooltip inside the stage with a 10px gap. There's no arrow anchoring it to the cursor, so the shift at the extremes is imperceptible. Vertical placement was clear at every sample point and is left alone.

## 5. Documentation (`fc3f689`)

These defects were all invisible in source and only showed up under measurement, so the constraints behind them are now written down.

`CLAUDE.md` gains a **Typography** section: `font-synthesis: none` means a face missing from the font URL fails silently rather than being synthesised, Space Grotesk stops at 700, italics need the `1,...` axis, Space Grotesk has a `tnum` table and DM Sans does not, and webfonts always need a fallback stack.

A new `verify-in-browser` skill (`.claude/skills/`) records the Playwright setup for this sandbox and the measurement traps that produce confident wrong answers — chiefly that `document.fonts.check()` returns `true` for faces that do not exist and so cannot be used to test font availability.

## Verification

- `npm run build` passes; all 245 prerendered pages carry the updated font stylesheet.
- `npm run lint` — 0 errors (96 pre-existing warnings, none in the touched files).
- Italic face confirmed registered and active in Chromium (canvas metrics differ from upright).
- Tooltip sweep re-measured after the fix: worst-case overflow **0px on all four edges** at both widths, with mid-profile positions unchanged.

No unit tests exist for this area, and the change is visual, so verification is the build/lint pair plus the browser measurements above.