### PR TITLE
Type the Mapbox GL surface instead of `any`

### DIFF
--- a/vite-project/src/components/utils/MapboxRoutePreview.tsx
+++ b/vite-project/src/components/utils/MapboxRoutePreview.tsx
@@ -9,6 +9,7 @@ import {
   type BudgetDenialReason,
   type RoutePoint,
 } from "@/lib/mapbox";
+import type { MapboxMap, MapboxMarker } from "@/lib/mapbox/gl-types";
 import { cn } from "@/lib/utils";
 import RouteSketch from "./RouteSketch";
 
@@ -73,10 +74,8 @@ export function MapboxRoutePreview({
   highlightPoint = null,
 }: MapboxRoutePreviewProps) {
   const mapContainer = useRef<HTMLDivElement>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const map = useRef<any>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const highlightMarker = useRef<any>(null);
+  const map = useRef<MapboxMap | null>(null);
+  const highlightMarker = useRef<MapboxMarker | null>(null);
 
   const [status, setStatus] = useState<PreviewStatus>("loading");
   const [blockedReason, setBlockedReason] = useState<BudgetDenialReason>();
@@ -150,8 +149,7 @@ export function MapboxRoutePreview({
         // first load is fatal, and that one has to tear the map down: a map
         // left behind on a hidden node holds a WebGL context and keeps
         // fetching tiles we are still paying for.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        map.current.on("error", (event: any) => {
+        map.current.on("error", (event) => {
           if (loaded) {
             console.error("Mapbox GL error:", event?.error ?? event);
             return;
@@ -284,7 +282,7 @@ export function MapboxRoutePreview({
       return;
     }
 
-    const lngLat = [highlightPoint.lng, highlightPoint.lat];
+    const lngLat: [number, number] = [highlightPoint.lng, highlightPoint.lat];
     if (highlightMarker.current) {
       highlightMarker.current.setLngLat(lngLat);
     } else {

--- a/vite-project/src/components/utils/StaticRouteMap.tsx
+++ b/vite-project/src/components/utils/StaticRouteMap.tsx
@@ -135,8 +135,12 @@ export function StaticRouteMap({
     return () => window.clearInterval(timer);
   }, [status, retryAfterMs]);
 
-  const goLive = useCallback(() => setLive(true), []);
-  const goStatic = useCallback(() => setLive(false), []);
+  const goLive = useCallback(() => {
+    setLive(true);
+  }, []);
+  const goStatic = useCallback(() => {
+    setLive(false);
+  }, []);
 
   const blockedNote =
     status === "blocked"

--- a/vite-project/src/features/poster/hooks/useMapbox.ts
+++ b/vite-project/src/features/poster/hooks/useMapbox.ts
@@ -6,6 +6,7 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { consumeMapboxBudget, loadMapboxGl } from "@/lib/mapbox";
+import type { MapboxMap, MapboxMarker } from "@/lib/mapbox/gl-types";
 import { type GpxPoint, type PosterData, MAPBOX_TOKEN } from "../types";
 import { calculateZoom, calculateCenter } from "../utils/mapbox";
 
@@ -19,8 +20,7 @@ interface UseMapboxProps {
 
 interface UseMapboxReturn {
   mapReady: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mapRef: React.MutableRefObject<any>;
+  mapRef: React.MutableRefObject<MapboxMap | null>;
   getMapCanvas: () => HTMLCanvasElement | null;
   waitForMapReady: () => Promise<void>;
 }
@@ -32,10 +32,8 @@ export function useMapbox({
   posterData,
   onMapUpdate,
 }: UseMapboxProps): UseMapboxReturn {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mapRef = useRef<any>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const markersRef = useRef<any[]>([]);
+  const mapRef = useRef<MapboxMap | null>(null);
+  const markersRef = useRef<MapboxMarker[]>([]);
   const { toast } = useToast();
 
   const [mapReady, setMapReady] = useState(false);
@@ -121,9 +119,13 @@ export function useMapbox({
           preserveDrawingBuffer: true, // CRITICAL for canvas export
         });
 
-        mapRef.current.on("load", () => {
+        // Captured once: the cleanup below nulls mapRef.current, and these
+        // handlers fire asynchronously after that.
+        const map = mapRef.current;
+
+        map.on("load", () => {
           // Add route line
-          mapRef.current.addSource("route", {
+          map.addSource("route", {
             type: "geojson",
             data: {
               type: "Feature",
@@ -135,7 +137,7 @@ export function useMapbox({
             },
           });
 
-          mapRef.current.addLayer({
+          map.addLayer({
             id: "route",
             type: "line",
             source: "route",
@@ -154,7 +156,7 @@ export function useMapbox({
         });
 
         // Set up move end listener
-        mapRef.current.on("moveend", () => {
+        map.on("moveend", () => {
           onMapUpdate?.();
         });
       } catch (error) {
@@ -177,8 +179,9 @@ export function useMapbox({
   // Update map style when template changes
   useEffect(() => {
     if (!mapRef.current || !mapReady) return;
+    const map = mapRef.current;
 
-    const currentStyle = mapRef.current.getStyle();
+    const currentStyle = map.getStyle();
     const currentStyleUrl = currentStyle?.sprite
       ?.split("/styles/")[1]
       ?.split("/")[0];
@@ -194,21 +197,21 @@ export function useMapbox({
     // Only reload style if it actually changed
     if (currentStyleUrl !== newStyleUrl) {
       console.log("🔄 Style changing to:", currentMapStyle);
-      mapRef.current.setStyle(currentMapStyle);
+      map.setStyle(currentMapStyle);
 
       // Re-add route after style loads
-      mapRef.current.once("styledata", () => {
+      map.once("styledata", () => {
         console.log(
           "🎨 Style loaded, re-adding route with color:",
           posterData.routeColor
         );
 
-        if (mapRef.current.getSource("route")) {
-          mapRef.current.removeLayer("route");
-          mapRef.current.removeSource("route");
+        if (map.getSource("route")) {
+          map.removeLayer("route");
+          map.removeSource("route");
         }
 
-        mapRef.current.addSource("route", {
+        map.addSource("route", {
           type: "geojson",
           data: {
             type: "Feature",
@@ -220,7 +223,7 @@ export function useMapbox({
           },
         });
 
-        mapRef.current.addLayer({
+        map.addLayer({
           id: "route",
           type: "line",
           source: "route",
@@ -237,9 +240,9 @@ export function useMapbox({
         console.log("✅ Route layer added after style change");
 
         // Wait for idle to ensure everything is rendered
-        mapRef.current.once("idle", () => {
+        map.once("idle", () => {
           console.log("✅ Map idle after style change");
-          mapRef.current.fire("moveend");
+          map.fire("moveend");
         });
       });
     } else {
@@ -255,26 +258,27 @@ export function useMapbox({
       console.log("⏳ Color update blocked: map not ready");
       return;
     }
+    const map = mapRef.current;
 
     // Short delay to ensure style change effect completed if triggered
     const timer = setTimeout(() => {
       // Wait for style to be fully loaded before updating paint properties
-      if (!mapRef.current.isStyleLoaded()) {
+      if (!map.isStyleLoaded()) {
         console.log("⏳ Style not loaded, skipping color update");
         return;
       }
 
       // Check if layer exists before updating
-      if (mapRef.current.getLayer("route")) {
+      if (map.getLayer("route")) {
         console.log("🎨 Updating route color to:", posterData.routeColor);
-        mapRef.current.setPaintProperty(
+        map.setPaintProperty(
           "route",
           "line-color",
           posterData.routeColor
         );
 
         // Force a repaint to ensure the color change is visible
-        mapRef.current.triggerRepaint();
+        map.triggerRepaint();
       } else {
         console.log("⚠️ Route layer not found for color update");
       }

--- a/vite-project/src/lib/mapbox/gl-types.ts
+++ b/vite-project/src/lib/mapbox/gl-types.ts
@@ -1,0 +1,92 @@
+/**
+ * Minimal structural types for the Mapbox GL JS surface we actually use.
+ *
+ * GL JS is loaded from the CDN, so it brings no types with it. Declaring the
+ * whole thing `any` costs real checking: `map.addLayer({ padnt: {...} })` would
+ * compile, and every call site inherits `any` from there.
+ *
+ * This is deliberately partial — add members here as call sites need them
+ * rather than widening anything back to `any`.
+ */
+
+export type LngLatTuple = [number, number];
+
+export interface GeoJsonLineSource {
+  type: "geojson";
+  data: {
+    type: "Feature";
+    properties: Record<string, unknown>;
+    geometry: { type: "LineString"; coordinates: LngLatTuple[] };
+  };
+}
+
+export interface LineLayerSpec {
+  id: string;
+  type: "line";
+  source: string;
+  layout?: { "line-join"?: string; "line-cap"?: string };
+  paint?: { "line-color"?: string; "line-width"?: number };
+}
+
+export interface MapboxGlError {
+  error?: { message?: string };
+  [key: string]: unknown;
+}
+
+export interface MapOptions {
+  container: HTMLElement;
+  style: string;
+  bounds?: MapboxLngLatBounds;
+  center?: LngLatTuple;
+  zoom?: number;
+  fitBoundsOptions?: { padding?: number };
+  interactive?: boolean;
+  minZoom?: number;
+  maxZoom?: number;
+  scrollZoom?: boolean;
+  doubleClickZoom?: boolean;
+  boxZoom?: boolean;
+  touchZoomRotate?: boolean;
+  preserveDrawingBuffer?: boolean;
+}
+
+/** Only the events we bind. */
+export type MapEvent = "load" | "error" | "moveend" | "styledata" | "idle";
+
+export interface MapboxMap {
+  on(event: MapEvent, handler: (event: MapboxGlError) => void): void;
+  once(event: MapEvent, handler: (event: MapboxGlError) => void): void;
+  fire(event: MapEvent): void;
+  addSource(id: string, source: GeoJsonLineSource): void;
+  removeSource(id: string): void;
+  getSource(id: string): unknown;
+  addLayer(layer: LineLayerSpec): void;
+  removeLayer(id: string): void;
+  getLayer(id: string): unknown;
+  getStyle(): { sprite?: string } | undefined;
+  setStyle(style: string): void;
+  setPaintProperty(layer: string, property: string, value: string | number): void;
+  triggerRepaint(): void;
+  isStyleLoaded(): boolean;
+  loaded(): boolean;
+  getCanvas(): HTMLCanvasElement;
+  remove(): void;
+}
+
+export interface MapboxMarker {
+  setLngLat(lngLat: LngLatTuple): MapboxMarker;
+  addTo(map: MapboxMap): MapboxMarker;
+  remove(): void;
+}
+
+export interface MapboxLngLatBounds {
+  readonly _brand?: never;
+}
+
+/** The `window.mapboxgl` namespace object. */
+export interface MapboxGl {
+  accessToken: string;
+  Map: new (options: MapOptions) => MapboxMap;
+  Marker: new (options?: { color?: string }) => MapboxMarker;
+  LngLatBounds: new (sw: LngLatTuple, ne: LngLatTuple) => MapboxLngLatBounds;
+}

--- a/vite-project/src/lib/mapbox/loader.ts
+++ b/vite-project/src/lib/mapbox/loader.ts
@@ -11,17 +11,15 @@
  */
 
 import { MAPBOX_GL_VERSION } from "./config";
+import type { MapboxGl } from "./gl-types";
 
 declare global {
   interface Window {
-    // GL JS has no bundled types when loaded from the CDN.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mapboxgl: any;
+    // Loaded from the CDN, so it arrives untyped; gl-types.ts declares the
+    // subset we call.
+    mapboxgl: MapboxGl | undefined;
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type MapboxGl = any;
 
 let loadPromise: Promise<MapboxGl> | null = null;
 

--- a/vite-project/src/lib/mapbox/useStaticRouteMap.ts
+++ b/vite-project/src/lib/mapbox/useStaticRouteMap.ts
@@ -38,6 +38,12 @@ export interface StaticRouteMapState {
 /** Shared across components so two previews of one route fetch once. */
 const inFlight = new Map<string, Promise<Blob>>();
 
+/**
+ * `url` is always built by `buildStaticMapRequest` from a fixed
+ * `https://api.mapbox.com/styles/v1/...` template with encoded coordinates —
+ * never a caller-supplied string. Static analysers flag this as SSRF; it is
+ * not one, but keep the invariant if you change how the URL is produced.
+ */
 const fetchStaticMap = (url: string, cacheKey: string): Promise<Blob> => {
   const existing = inFlight.get(cacheKey);
   if (existing) return existing;


### PR DESCRIPTION
Follow-up to the Mapbox rewrite, which landed on `main` as #84. This branch has been rebased onto that, so what remains here is one commit.

GL JS is loaded from the CDN and brings no types with it, and the rewrite declared the whole namespace `any`. Every call site inherited that — `map.addLayer({ padnt: {...} })` would have compiled clean.

`gl-types.ts` now declares the subset we actually call: `Map`, `Marker`, `LngLatBounds`, the five events we bind, and the geojson-source / line-layer shapes. Deliberately partial — add members as call sites need them rather than widening back to `any`.

## What the typing found

13 real null-safety gaps in the poster hook that `any` had been hiding. `mapRef.current.addSource(...)` and friends are called inside async `load` / `styledata` / `idle` handlers, all of which can fire *after* the effect cleanup sets `mapRef.current = null`. Each now captures the map in a local `const` at the point it is known non-null:

```ts
// cleanup nulls mapRef.current; these handlers fire after that
const map = mapRef.current;
map.on("load", () => { map.addSource("route", ...) });
```

Also here:

- Braces on two void-returning arrow shorthands.
- A note on `fetchStaticMap` recording why the Semgrep SSRF hit is a false positive — the URL is built from a fixed `api.mapbox.com` template, never a caller-supplied string — and which invariant to preserve if that changes.

## Verification

`tsc` clean, `npm run lint` 0 errors (92 warnings, unchanged baseline), `npm run build` green.

This touched every GL call site, so the full browser suite was re-run against the rebased tree: caching (13 loads → 1 request), budget block/recovery, `awaitingPoints`, both GL error paths, resize quantization — all identical to before the change.

## On the Codacy check

It is red, and this PR will not turn it green. Worth knowing why before anyone chases it:

Codacy's ESLint cannot resolve this project's `@/*` path alias. `RouteSketch.tsx` contains the string "any" exactly zero times yet carries 39 "unsafe member access on an `error` typed value" findings — all downstream of its `@/lib/mapbox` import. When the module does not resolve, TypeScript assigns the *error type* and every use of it gets flagged. The new `useRef<MapboxMap | null>` refs are now flagged as `no-redundant-type-constituents` for the same reason: Codacy resolves `MapboxMap` to `any`.

At this branch's head commit, **zero** findings are genuinely `any`-typed. The check was already `action_required` on #83 and #84, so it is chronic rather than caused here. The fix is Codacy configuration (teaching it `vite-project/tsconfig.app.json`), which is repo-wide and does not belong in this diff.